### PR TITLE
internal/exceptions: implemented some custom exceptions and cleaned up some of the error messages

### DIFF
--- a/base/_exceptions.py
+++ b/base/_exceptions.py
@@ -1,0 +1,136 @@
+import exceptions as E
+
+class MissingTagError(E.KeyError):
+    """
+    The requested tag at the specified address does not exist.
+    """
+
+class MissingFunctionTagError(MissingTagError):
+    """
+    The requested tag for the specified function does not exist.
+    """
+
+class MissingMethodError(E.NotImplementedError):
+    """
+    A method belonging to a superclass that is required to be overloaded was called.
+    """
+
+class UnsupportedVersion(E.NotImplementedError):
+    """
+    This functionality is not supported on the current version of IDA.
+    """
+
+class UnsupportedCapability(E.NotImplementedError, E.EnvironmentError):
+    """
+    An unexpected or unsupported capability was specified.
+    """
+
+class ResultMissingError(E.LookupError):
+    """
+    The requested item is missing from its results.
+    """
+
+class SearchResultsError(ResultMissingError):
+    """
+    No results were found.
+    """
+
+class DisassemblerError(E.EnvironmentError):
+    """
+    An api call has thrown an error or was unsuccessful.
+    """
+
+class MissingTypeOrAttribute(E.TypeError):
+    """
+    The specified location is missing some specific attribute or type.
+    """
+
+class InvalidTypeOrValueError(E.TypeError, E.ValueError):
+    """
+    An invalid value or type was specified.
+    """
+
+class InvalidParameterError(InvalidTypeOrValueError, E.AssertionError):
+    """
+    An invalid parameter was specified by the user.
+    """
+
+class OutOfBoundsError(E.ValueError):
+    """
+    The specified item is out of bounds.
+    """
+
+class AddressOutOfBoundsError(OutOfBoundsError, E.ArithmeticError):
+    """
+    The specified address is out of bounds.
+    """
+
+class IndexOutOfBoundsError(OutOfBoundsError, E.IndexError, E.KeyError):
+    """
+    The specified index is out of bounds.
+    """
+
+class ItemNotFoundError(ResultMissingError, E.KeyError):
+    """
+    The specified item or type was not found.
+    """
+
+class FunctionNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified function.
+    """
+
+class AddressNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified address.
+    """
+
+class SegmentNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified segment.
+    """
+
+class StructureNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified structure.
+    """
+
+class EnumerationNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified enumeration.
+    """
+
+class MemberNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified structure or enumeration member.
+    """
+
+class RegisterNotFoundError(ItemNotFoundError):
+    """
+    Unable to locate the specified register.
+    """
+
+class ReadOrWriteError(E.IOError, E.ValueError):
+    """
+    Unable to read or write the specified number of bytes .
+    """
+
+class InvalidFormatError(E.KeyError, E.ValueError):
+    """
+    The specified data has an invalid format.
+    """
+
+class SerializationError(E.ValueError, E.IOError):
+    """
+    There was an error while trying to serialize or deserialize the specified data.
+    """
+
+class SizeMismatchError(SerializationError):
+    """
+    There was an error while trying to serialize or deserialize the specified data due to its size not matching.
+    """
+
+#structure:742 and previous to it should output the module name, classname, and method
+#comment:334 should catch whatever tree.find raises
+#comment:100 (this needs some kind of error when the symbol or token component is not found)
+#interface:283, interface:302, interface:620, interface:640 (this should be a NameError)

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -108,9 +108,9 @@ class utils(object):
     def range(cls):
         this = netnode.new()
         ok, start = netnode.start(this), netnode.index(this)
-        if not ok: raise StandardError("{:s}.range : Unable to find first node.".format('.'.join((__name__,cls.__name__))))
+        if not ok: raise LookupError("{:s}.range : Unable to find first node.".format('.'.join(('internal', __name__, cls.__name__))))
         ok, end = netnode.end(this), netnode.index(this)
-        if not ok: raise StandardError("{:s}.range : Unable to find last node.".format('.'.join((__name__,cls.__name__))))
+        if not ok: raise LookupError("{:s}.range : Unable to find last node.".format('.'.join(('internal', __name__, cls.__name__))))
         return start, end
 
     @classmethod
@@ -324,15 +324,15 @@ class blob(object):
         if cls.size(nodeidx, tag) == 0:
             raise ValueError("Node {:x}({:s}) has no blob.".format(nodeidx, tag))
         res = cls.get(nodeidx, tag)
-        return repr(res)
+        return "{!r}".format(res)
 
 ### node iteration
 def riter():
-    for nodeidx,_ in utils.renumerate():
+    for nodeidx, _ in utils.renumerate():
         yield nodeidx
     return
 def fiter():
-    for nodeidx,_ in utils.fenumerate():
+    for nodeidx, _ in utils.fenumerate():
         yield nodeidx
     return
 
@@ -357,15 +357,15 @@ class alt(object):
     @classmethod
     def fiter(cls, nodeidx):
         node = netnode.new(nodeidx)
-        for idx,val in utils.falt(node):
-            yield idx,val
+        for idx, val in utils.falt(node):
+            yield idx, val
         return
 
     @classmethod
     def riter(cls, nodeidx):
         node = netnode.new(nodeidx)
-        for idx,val in utils.ralt(node):
-            yield idx,val
+        for idx, val in utils.ralt(node):
+            yield idx, val
         return
 
     @classmethod
@@ -380,6 +380,8 @@ class alt(object):
 ### node sup iteration
 class sup(object):
     '''Sparse array[int] of 1024b strings'''
+
+    MAX_SIZE = 0x400
 
     @classmethod
     def get(cls, nodeidx, idx, type=None):
@@ -403,14 +405,14 @@ class sup(object):
     @classmethod
     def fiter(cls, nodeidx):
         node = netnode.new(nodeidx)
-        for idx,_ in utils.fsup(node):
+        for idx, _ in utils.fsup(node):
             yield idx
         return
 
     @classmethod
     def riter(cls, nodeidx):
         node = netnode.new(nodeidx)
-        for idx,_ in utils.rsup(node):
+        for idx, _ in utils.rsup(node):
             yield idx
         return
 
@@ -460,14 +462,14 @@ class hash(object):
     @classmethod
     def fiter(cls, nodeidx):
         node = netnode.new(nodeidx)
-        for key,_ in utils.fhash(node):
+        for key, _ in utils.fhash(node):
             yield key
         return
 
     @classmethod
     def riter(cls, nodeidx):
         node = netnode.new(nodeidx)
-        for key,_ in utils.rhash(node):
+        for key, _ in utils.rhash(node):
             yield key
         return
 
@@ -476,12 +478,12 @@ class hash(object):
         res = []
         try:
             l1 = max(len(key or '') for key in cls.fiter(nodeidx))
-            l2 = max(len(repr(cls.get(nodeidx, key))) for key in cls.fiter(nodeidx))
+            l2 = max(len("{!r}".format(cls.get(nodeidx, key))) for key in cls.fiter(nodeidx))
         except ValueError:
             l1, l2 = 0, 2
 
         for i, key in enumerate(cls.fiter(nodeidx)):
-            val = "{:<{:d}s} : str=\"{:s}\", buffer={!r}, int={:#x}({:d})".format(repr(cls.get(nodeidx, key)), l2, cls.get(nodeidx, key, str), cls.get(nodeidx, key, buffer), cls.get(nodeidx, key, int), cls.get(nodeidx, key, int))
+            val = "{:<{:d}s} : str=\"{:s}\", buffer={!r}, int={:#x}({:d})".format("{!r}".format(cls.get(nodeidx, key)), l2, cls.get(nodeidx, key, str), cls.get(nodeidx, key, buffer), cls.get(nodeidx, key, int), cls.get(nodeidx, key, int))
             res.append("[{:d}] {:<{:d}s} -> {:s}".format(i, key, l1, val))
         if not res:
             raise ValueError("Node {:x} has no hashes.".format(nodeidx))

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -174,14 +174,14 @@ class multicase(object):
 
             # calculate the priority by trying to match the most first
             argtuple = s_args, args, defaults, (star, starstar)
-            priority = len(args) - s_args - len(t_args) + (len(args) and (next((float(i) for i,a in enumerate(args[s_args:]) if a in t_args), 0) / len(args))) + sum(0.3 for _ in filter(None, (star, starstar)))
+            priority = len(args) - s_args - len(t_args) + (len(args) and (next((float(i) for i, a in enumerate(args[s_args:]) if a in t_args), 0) / len(args))) + sum(0.3 for _ in filter(None, (star, starstar)))
 
             # check to see if our func is already in the cache
-            current = tuple(t_args.get(_,None) for _ in args),(star,starstar)
+            current = tuple(t_args.get(_, None) for _ in args), (star, starstar)
             for i, (p, (_, t, a)) in enumerate(cache):
                 if p != priority: continue
                 # verify that it actually matches the entry
-                if current == (tuple(t.get(_,None) for _ in a[1]), a[3]):
+                if current == (tuple(t.get(_, None) for _ in a[1]), a[3]):
                     # yuuup, update it.
                     cache[i] = (priority, (func, t_args, argtuple))
                     res.__doc__ = cls.document(func.__name__, [n for _, n in cache])
@@ -198,7 +198,7 @@ class multicase(object):
             return cons(res)
 
         if len(other) > 1:
-            raise SyntaxError("{:s} : More than one callable was specified ({!r}). Not sure which callable to clone original state from.".format('.'.join((__name__, cls.__name__)), other))
+            raise SyntaxError("{:s} : More than one callable was specified ({!r}). Not sure which callable to clone original state from.".format('.'.join(('internal', __name__, cls.__name__)), other))
         return result
 
     @classmethod
@@ -264,15 +264,15 @@ class multicase(object):
 
         error_arguments = (n.__class__.__name__ for n in args)
         error_keywords = ("{:s}={:s}".format(n, kwds[n].__class__.__name__) for n in kwds)
-        raise LookupError("@multicase.call({:s}, The type {{{:s}}}) does not match any of the available prototypes. The prototypes that are available are {:s}.".format(', '.join(error_arguments) if args else '*()', ', '.join(error_keywords), ', '.join(cls.prototype(f,t) for f,t,_ in heap)))
+        raise LookupError("@multicase.call({:s}, The type {{{!s}}}) does not match any of the available prototypes. The prototypes that are available are {:s}.".format(', '.join(error_arguments) if args else '*()', ', '.join(error_keywords), ', '.join(cls.prototype(f, t) for f, t, _ in heap)))
 
     @classmethod
     def new_wrapper(cls, func, cache):
         '''Create a new wrapper that will determine the correct function to call.'''
         # define the wrapper...
         def F(*arguments, **keywords):
-            heap = [res for _,res in heapq.nsmallest(len(cache), cache)]
-            f, (a, w, k) = cls.match((arguments[:],keywords), heap)
+            heap = [res for _, res in heapq.nsmallest(len(cache), cache)]
+            f, (a, w, k) = cls.match((arguments[:], keywords), heap)
             return f(*arguments, **keywords)
             #return f(*(arguments + tuple(w)), **keywords)
 
@@ -302,7 +302,7 @@ class multicase(object):
         elif isinstance(object, types.CodeType):
             res, = (n for n in gc.get_referrers(c) if n.func_name == c.co_name and isinstance(n, types.FunctionType))
             return res
-        elif isinstance(object, (staticmethod,classmethod)):
+        elif isinstance(object, (staticmethod, classmethod)):
             return object.__func__
         raise TypeError, object
 
@@ -313,11 +313,11 @@ class multicase(object):
             return lambda f: f
         if isinstance(n, types.MethodType):
             return lambda f: types.MethodType(f, n.im_self, n.im_class)
-        if isinstance(n, (staticmethod,classmethod)):
+        if isinstance(n, (staticmethod, classmethod)):
             return lambda f: type(n)(f)
         if isinstance(n, types.InstanceType):
             return lambda f: types.InstanceType(type(n), dict(f.__dict__))
-        if isinstance(n, (types.TypeType,types.ClassType)):
+        if isinstance(n, (types.TypeType, types.ClassType)):
             return lambda f: type(n)(n.__name__, n.__bases__, dict(f.__dict__))
         raise NotImplementedError, type(func)
 
@@ -327,7 +327,7 @@ class multicase(object):
         c = f.func_code
         varnames_count, varnames_iter = c.co_argcount, iter(c.co_varnames)
         args = tuple(itertools.islice(varnames_iter, varnames_count))
-        res = { a : v for v,a in zip(reversed(f.func_defaults or []), reversed(args)) }
+        res = { a : v for v, a in zip(reversed(f.func_defaults or []), reversed(args)) }
         try: starargs = next(varnames_iter) if c.co_flags & cls.CO_VARARGS else ""
         except StopIteration: starargs = ""
         try: kwdargs = next(varnames_iter) if c.co_flags & cls.CO_VARKEYWORDS else ""
@@ -361,7 +361,7 @@ class alias(object):
         return res
 
 ### asynchronous process monitor
-import sys,os,threading,weakref,subprocess,time,itertools,operator
+import sys, os, threading, weakref, subprocess, time, itertools, operator
 
 # monitoring an external process' i/o via threads/queues
 class process(object):
@@ -371,7 +371,7 @@ class process(object):
     program -- subprocess.Popen instance
     commandline -- subprocess.Popen commandline
     eventWorking -- threading.Event() instance for signalling task status to monitor threads
-    stdout,stderr -- callables that are used to process available work in the taskQueue
+    stdout, stderr -- callables that are used to process available work in the taskQueue
 
     properties:
     id -- subprocess pid
@@ -420,7 +420,7 @@ class process(object):
         self.stderr = kwds.pop('stderr')
 
         # start the process
-        not kwds.get('paused',False) and self.start(command)
+        not kwds.get('paused', False) and self.start(command)
 
     def start(self, command=None, **options):
         '''Start the specified ``command`` with the requested ``options``.'''
@@ -437,14 +437,14 @@ class process(object):
         cwd = kwds.get('cwd', os.getcwd())
         newlines = kwds.get('newlines', True)
         shell = kwds.get('shell', False)
-        stdout,stderr = options.pop('stdout',self.stdout),options.pop('stderr',self.stderr)
+        stdout, stderr = options.pop('stdout', self.stdout), options.pop('stderr', self.stderr)
         self.program = process.subprocess(command, cwd, env, newlines, joined=(stderr is None) or stdout == stderr, shell=shell, show=kwds.get('show', False))
         self.commandline = command
         self.eventWorking.clear()
 
         # monitor program's i/o
         self.__start_monitoring(stdout, stderr)
-        self.__start_updater(timeout=kwds.get('timeout',-1))
+        self.__start_updater(timeout=kwds.get('timeout', -1))
 
         # start monitoring
         self.eventWorking.set()
@@ -454,19 +454,19 @@ class process(object):
         '''Start the updater thread. **used internally**'''
         import Queue
         def task_exec(emit, data):
-            if hasattr(emit,'send'):
+            if hasattr(emit, 'send'):
                 res = emit.send(data)
                 res and P.write(res)
             else: emit(data)
 
         def task_get_timeout(P, timeout):
             try:
-                emit,data = P.taskQueue.get(block=True, timeout=timeout)
+                emit, data = P.taskQueue.get(block=True, timeout=timeout)
             except Queue.Empty:
-                _,_,tb = sys.exc_info()
-                P.exceptionQueue.put(StopIteration,StopIteration(),tb)
+                _, _, tb = sys.exc_info()
+                P.exceptionQueue.put(StopIteration, StopIteration(), tb)
                 return ()
-            return emit,data
+            return emit, data
 
         def task_get_notimeout(P, timeout):
             return P.taskQueue.get(block=True)
@@ -478,10 +478,10 @@ class process(object):
             while P.eventWorking.is_set():
                 res = task_get(P, timeout)
                 if not res: continue
-                emit,data = res
+                emit, data = res
 
                 try:
-                    task_exec(emit,data)
+                    task_exec(emit, data)
                 except StopIteration:
                     P.eventWorking.clear()
                 except:
@@ -491,7 +491,7 @@ class process(object):
                 continue
             return
 
-        self.__updater = updater = threading.Thread(target=update, name="thread-%x.update"% self.id, args=(self,timeout))
+        self.__updater = updater = threading.Thread(target=update, name="thread-%x.update"% self.id, args=(self, timeout))
         updater.daemon = daemon
         updater.start()
         return updater
@@ -503,14 +503,14 @@ class process(object):
 
         # create monitoring threads + coroutines
         if stderr:
-            res = process.monitorPipe(self.taskQueue, (stdout,program.stdout),(stderr,program.stderr), name=name)
+            res = process.monitorPipe(self.taskQueue, (stdout, program.stdout), (stderr, program.stderr), name=name)
         else:
-            res = process.monitorPipe(self.taskQueue, (stdout,program.stdout), name=name)
+            res = process.monitorPipe(self.taskQueue, (stdout, program.stdout), name=name)
 
         res = map(None, res)
         # attach a method for injecting data into a monitor
-        for t,q in res: t.send = q.send
-        threads,senders = zip(*res)
+        for t, q in res: t.send = q.send
+        threads, senders = zip(*res)
 
         # update threads for destruction later
         self.__threads.update(threads)
@@ -531,18 +531,18 @@ class process(object):
         return subprocess.Popen(program, universal_newlines=newlines, shell=shell, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr, close_fds=True, cwd=cwd, env=environment)
 
     @staticmethod
-    def monitorPipe(q, (id,pipe), *more, **options):
+    def monitorPipe(q, (id, pipe), *more, **options):
         """Attach a coroutine to a monitoring thread for stuffing queue `q` with data read from `pipe`
 
-        Yields a list of (thread,coro) tuples given the arguments provided.
+        Yields a list of (thread, coro) tuples given the arguments provided.
         Each thread will read from `pipe`, and stuff the value combined with `id` into `q`.
         """
-        def stuff(q,*key):
-            while True: q.put(key+((yield),))
+        def stuff(q, *key):
+            while True: q.put(key + ((yield),))
 
-        for id,pipe in itertools.chain([(id,pipe)],more):
-            res,name = stuff(q,id), "{:s}<{!r}>".format(options.get('name',''),id)
-            yield process.monitor(res.next() or res.send, pipe, name=name),res
+        for id, pipe in itertools.chain([(id, pipe)], more):
+            res, name = stuff(q, id), "{:s}<{!r}>".format(options.get('name', ''), id)
+            yield process.monitor(res.next() or res.send, pipe, name=name), res
         return
 
     @staticmethod
@@ -562,12 +562,12 @@ class process(object):
                     # determine why (cause...y'know..python), stop dancing so
                     # the parent will actually be able to terminate us
                     break
-                map(send,data)
+                map(send, data)
             return
         if name:
-            monitorThread = threading.Thread(target=shuffle, name=name, args=(send,pipe))
+            monitorThread = threading.Thread(target=shuffle, name=name, args=(send, pipe))
         else:
-            monitorThread = threading.Thread(target=shuffle, args=(send,pipe))
+            monitorThread = threading.Thread(target=shuffle, args=(send, pipe))
         monitorThread.daemon = daemon
         return monitorThread
 
@@ -618,7 +618,7 @@ class process(object):
             while self.running and self.eventWorking.is_set() and time.time() - t < timeout:        # spin cpu until we timeout
                 if not self.exceptionQueue.empty():
                     res = self.exception()
-                    raise res[0],res[1],res[2]
+                    raise res[0], res[1], res[2]
                 continue
             return program.returncode if self.eventWorking.is_set() else self.__terminate()
 
@@ -628,7 +628,7 @@ class process(object):
         while self.running and self.eventWorking.is_set():
             if not self.exceptionQueue.empty():
                 res = self.exception()
-                raise res[0],res[1],res[2]
+                raise res[0], res[1], res[2]
             continue    # ugh...poll-forever/kill-cpu until program terminates...
 
         if not self.eventWorking.is_set():
@@ -649,7 +649,7 @@ class process(object):
             return self.program.returncode
 
         res = self.exception()
-        raise res[0],res[1],res[2]
+        raise res[0], res[1], res[2]
 
     def __stop_monitoring(self):
         '''Cleanup monitoring threads.'''
@@ -662,7 +662,7 @@ class process(object):
 
         # forcefully close pipes that still open, this should terminate the monitor threads
         #   also, this fixes a resource leak since python doesn't do this on subprocess death
-        for p in (P.stdin,P.stdout,P.stderr):
+        for p in (P.stdin, P.stdout, P.stderr):
             while p and not p.closed:
                 try: p.close()
                 except: pass
@@ -692,7 +692,7 @@ class process(object):
             ('updater', 0 if self.updater is None else self.updater.is_alive()),
             ('input/output', len(self.threads))
         ]
-        return "<process {:s}{:s} threads{{{:s}}}>".format(state, (' !exception!' if not ok else ''), ' '.join("{:s}:{:d}".format(n,v) for n,v in threads))
+        return "<process {:s}{:s} threads{{{:s}}}>".format(state, (' !exception!' if not ok else ''), ' '.join("{:s}:{:d}".format(n, v) for n, v in threads))
 
 ## interface for wrapping the process class
 def spawn(stdout, command, **options):
@@ -706,10 +706,10 @@ def spawn(stdout, command, **options):
     daemon = options.pop('daemon', True)
 
     # empty out the first generator result if a coroutine is passed
-    if hasattr(stdout,'send'):
+    if hasattr(stdout, 'send'):
         res = stdout.next()
         res and P.write(res)
-    if hasattr(stderr,'send'):
+    if hasattr(stderr, 'send'):
         res = stderr.next()
         res and P.write(res)
 
@@ -718,8 +718,8 @@ def spawn(stdout, command, **options):
 
 ### scheduler
 class execution(object):
-    __slots__ = ('queue','state','result','ev_unpaused','ev_terminating')
-    __slots__+= ('thread','lock')
+    __slots__ = ('queue', 'state', 'result', 'ev_unpaused', 'ev_terminating')
+    __slots__+= ('thread', 'lock')
 
     def __init__(self):
         '''Execute a function asynchronously in another thread.'''
@@ -764,14 +764,14 @@ class execution(object):
         if not self.thread.is_alive():
             state = 'dead'
         res = tuple(self.state)
-        return "<class '{:s}'> {:s} Queue:{:d} Results:{:d}".format('.'.join(('internal',__name__,cls.__name__)), state, len(res), self.result.unfinished_tasks)
+        return "<class '{:s}'> {:s} Queue:{:d} Results:{:d}".format('.'.join(('internal', __name__, cls.__name__)), state, len(res), self.result.unfinished_tasks)
 
     running = property(fget=lambda s: s.thread.is_alive() and s.ev_unpaused.is_set() and not s.ev_terminating.is_set())
     dead = property(fget=lambda s: s.thread.is_alive())
 
     def notify(self):
         '''Notify the execution queue that it should process anything that is queued.'''
-        logging.debug("{:s}.notify : Waking up execution queue {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self))
+        logging.debug("{:s}.notify : Waking up execution queue {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self))
         self.queue.acquire()
         self.queue.notify()
         self.queue.release()
@@ -789,17 +789,17 @@ class execution(object):
 
     def __start(self):
         cls = self.__class__
-        logging.debug("{:s}.start : Starting execution queue thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self.thread))
+        logging.debug("{:s}.start : Starting execution queue thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self.thread))
         self.ev_terminating.clear(), self.ev_unpaused.set()
         self.thread.daemon = True
         return self.thread.start()
 
     def __stop(self):
         cls = self.__class__
-        logging.debug("{:s}.stop : Terminating execution queue thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self.thread))
+        logging.debug("{:s}.stop : Terminating execution queue thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self.thread))
         if not self.thread.is_alive():
             cls = self.__class__
-            logging.warn("{:s}.stop : Execution queue has already been terminated as {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self))
+            logging.warn("{:s}.stop : Execution queue has already been terminated as {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self))
             return
         self.ev_unpaused.set(), self.ev_terminating.set()
         self.queue.acquire()
@@ -811,9 +811,9 @@ class execution(object):
         '''Start to dispatch callables in the execution queue.'''
         cls = self.__class__
         if not self.thread.is_alive():
-            logging.fatal("{:s}.start : Unable to resume an already terminated execution queue {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self))
+            logging.fatal("{:s}.start : Unable to resume an already terminated execution queue {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self))
             return False
-        logging.info("{:s}.start : Resuming the execution queue {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self.thread))
+        logging.info("{:s}.start : Resuming the execution queue {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self.thread))
         res, _ = self.ev_unpaused.is_set(), self.ev_unpaused.set()
         self.queue.acquire()
         self.queue.notify_all()
@@ -824,9 +824,9 @@ class execution(object):
         '''Pause the execution queue.'''
         cls = self.__class__
         if not self.thread.is_alive():
-            logging.fatal("{:s}.stop : Unable to pause the execution queue {!r} as it has already been terminated.".format('.'.join(('internal',__name__,cls.__name__)), self))
+            logging.fatal("{:s}.stop : Unable to pause the execution queue {!r} as it has already been terminated.".format('.'.join(('internal', __name__, cls.__name__)), self))
             return False
-        logging.info("{:s}.stop : Pausing execution queue thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self.thread))
+        logging.info("{:s}.stop : Pausing execution queue thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self.thread))
         res, _ = self.ev_unpaused.is_set(), self.ev_unpaused.clear()
         self.queue.acquire()
         self.queue.notify_all()
@@ -839,7 +839,7 @@ class execution(object):
         res = functools.partial(F, *args, **kwds)
 
         cls = self.__class__
-        logging.debug("{:s}.push : Adding the callable {!r} to the execution queue {!r}.".format('.'.join(('internal',__name__,cls.__name__)), F, self))
+        logging.debug("{:s}.push : Adding the callable {!r} to the execution queue {!r}.".format('.'.join(('internal', __name__, cls.__name__)), F, self))
         # shove it down a multiprocessing.Queue
         self.queue.acquire()
         self.state.append(res)
@@ -851,10 +851,10 @@ class execution(object):
         '''Pop a result off of the result queue.'''
         cls = self.__class__
         if not self.thread.is_alive():
-            logging.fatal("{:s}.pop : Refusing to wait for a result when execution queue has already terminated. Execution queue is {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self))
+            logging.fatal("{:s}.pop : Refusing to wait for a result when execution queue has already terminated. Execution queue is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self))
             raise Queue.Empty
 
-        logging.debug("{:s}.pop : Popping result off of the execution queue {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self))
+        logging.debug("{:s}.pop : Popping result off of the execution queue {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self))
         try:
             _, res, err = self.result.get(block=0)
             if err != (None, None, None):
@@ -893,14 +893,14 @@ class execution(object):
         consumer = self.__consume(self.ev_terminating, self.queue, self.state)
         executor = self.__dispatch(self.lock); next(executor)
 
-        logging.debug("{:s}.running : The execution queue is now running with thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self.thread))
+        logging.debug("{:s}.running : The execution queue is now running with thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self.thread))
         while not self.ev_terminating.is_set():
             # check if we're allowed to execute
             if not self.ev_unpaused.is_set():
                 self.ev_unpaused.wait()
 
             # pull a callable out of the queue
-            logging.debug("{:s}.running : Waiting for an item on thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), self.thread))
+            logging.debug("{:s}.running : Waiting for an item on thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), self.thread))
             self.queue.acquire()
             item = next(consumer)
             self.queue.release()
@@ -912,12 +912,12 @@ class execution(object):
             if self.ev_terminating.is_set(): break
 
             # now we can execute it
-            logging.debug("{:s}.running : Executing {!r} asynchronously with thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), item, self.thread))
+            logging.debug("{:s}.running : Executing {!r} asynchronously with thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), item, self.thread))
             res, err = executor.send(item)
 
             # and stash our result
-            logging.debug("{:s}.running : Received result {!r} from {!r} on thread {!r}.".format('.'.join(('internal',__name__,cls.__name__)), (res,err), item, self.thread))
-            self.result.put((item,res,err))
+            logging.debug("{:s}.running : Received result {!r} from {!r} on thread {!r}.".format('.'.join(('internal', __name__, cls.__name__)), (res, err), item, self.thread))
+            self.result.put((item, res, err))
         return
 
 # FIXME: figure out how to match against a bounds in a non-hacky way
@@ -931,7 +931,7 @@ class matcher(object):
     def __attrib__(self, *attribute):
         if not attribute:
             return lambda n: n
-        res = [(operator.attrgetter(a) if isinstance(a,basestring) else a) for a in attribute]
+        res = [(operator.attrgetter(a) if isinstance(a, basestring) else a) for a in attribute]
         return lambda o: tuple(x(o) for x in res) if len(res) > 1 else res[0](o)
     def attribute(self, type, *attribute):
         attr = self.__attrib__(*attribute)

--- a/base/database.py
+++ b/base/database.py
@@ -696,7 +696,10 @@ class search(object):
         """
         reverseQ = builtins.next((direction[k] for k in ('reverse', 'reversed', 'up', 'backwards') if k in direction), False)
         flags = idaapi.SEARCH_UP if reverseQ else idaapi.SEARCH_DOWN
-        return idaapi.find_binary(ea, idaapi.BADADDR, ' '.join("{:d}".format(six.byte2int(ch)) for ch in string), direction.get('radix', 16), idaapi.SEARCH_CASE | flags)
+        res = idaapi.find_binary(ea, idaapi.BADADDR, ' '.join("{:d}".format(six.byte2int(ch)) for ch in string), direction.get('radix', 16), idaapi.SEARCH_CASE | flags)
+        if res == idaapi.BADADDR:
+            raise E.SearchResultsError("{:s}.by_bytes({:#x}, {!r}{:s}) : The specified bytes were not found.".format('.'.join((__name__, search.__name__)), ea, string, ", {:s}".format(', '.join("{:s}={!r}".format(key, value) for key, value in six.iteritems(direction))) if direction else '', res))
+        return res
     byBytes = by_bytes
 
     @utils.multicase(string=basestring)
@@ -716,7 +719,10 @@ class search(object):
         flags = idaapi.SEARCH_REGEX
         flags |= idaapi.SEARCH_UP if reverseQ else idaapi.SEARCH_DOWN
         flags |= idaapi.SEARCH_CASE if options.get('sensitive', False) else 0
-        return idaapi.find_text(ea, 0, 0, string, flags)
+        res = idaapi.find_text(ea, 0, 0, string, flags)
+        if res == idaapi.BADADDR:
+            raise E.SearchResultsError("{:s}.by_regex({:#x}, {!r}{:s}) : The specified regex was not found.".format('.'.join((__name__, search.__name__)), ea, string, ", {:s}".format(', '.join("{:s}={!r}".format(key, value) for key, value in six.iteritems(options))) if options else '', res))
+        return res
     byRegex = by_regex
 
     @utils.multicase(string=basestring)
@@ -736,7 +742,10 @@ class search(object):
         flags = 0
         flags |= idaapi.SEARCH_UP if reverseQ else idaapi.SEARCH_DOWN
         flags |= idaapi.SEARCH_CASE if options.get('sensitive', False) else 0
-        return idaapi.find_text(ea, 0, 0, string, flags)
+        res = idaapi.find_text(ea, 0, 0, string, flags)
+        if res == idaapi.BADADDR:
+            raise E.SearchResultsError("{:s}.by_text({:#x}, {!r}{:s}) : The specified text was not found.".format('.'.join((__name__, search.__name__)), ea, string, ", {:s}".format(', '.join("{:s}={!r}".format(key, value) for key, value in six.iteritems(options))) if options else '', res))
+        return res
     byText = utils.alias(by_text, 'search')
 
     @utils.multicase(name=basestring)
@@ -756,7 +765,10 @@ class search(object):
         flags = idaapi.SEARCH_IDENT
         flags |= idaapi.SEARCH_UP if reverseQ else idaapi.SEARCH_DOWN
         flags |= idaapi.SEARCH_CASE if options.get('sensitive', False) else 0
-        return idaapi.find_text(ea, 0, 0, name, flags)
+        res = idaapi.find_text(ea, 0, 0, name, flags)
+        if res == idaapi.BADADDR:
+            raise E.SearchResultsError("{:s}.by_name({:#x}, {!r}{:s}) : The specified name was not found.".format('.'.join((__name__, search.__name__)), ea, string, ", {:s}".format(', '.join("{:s}={!r}".format(key, value) for key, value in six.iteritems(options))) if options else '', res))
+        return res
     byName = utils.alias(by_name, 'search')
 
     @utils.multicase(string=basestring)

--- a/custom/tagfix.py
+++ b/custom/tagfix.py
@@ -151,7 +151,7 @@ def contents(ea):
     '''Re-build the cache for the contents of the function ``ea``.'''
     try:
         func.address(ea)
-    except LookupError:
+    except internal.exceptions.FunctionNotFoundError:
         return {}, {}
 
     # read addresses and tags from contents

--- a/custom/tags.py
+++ b/custom/tags.py
@@ -127,7 +127,7 @@ class read(object):
 
             # if it's a structure, then the type is the structure name
             if isinstance(member.type, struc.structure_t):
-                logging.info("{:s}.frame({:#x}) : Storing structure-based type as name for field {:+#x} with tne type {!r}.".format('.'.join((__name__, cls.__name__)), ea, member.offset, member.type))
+                logging.info("{:s}.frame({:#x}) : Storing structure-based type as name for field {:+#x} with tne type {!s}.".format('.'.join((__name__, cls.__name__)), ea, member.offset, member.type))
                 type = member.type.name
 
             # otherwise, the type is a tuple that we can serializer
@@ -190,7 +190,7 @@ class read(object):
 
             # otherwise, try the next address till we hit a sentinel value
             try: ea = db.a.next(ea)
-            except StandardError: ea = sentinel
+            except internal.exceptions.OutOfBoundsError: ea = sentinel
         return
 
     ## reading the contents from the entire database
@@ -263,7 +263,7 @@ class apply(object):
         for offset, (name, type, comment) in six.iteritems(frame):
             try:
                 member = F.by_offset(offset)
-            except LookupError:
+            except internal.exceptions.MemberNotFoundError:
                 logging.warn("{:s}.frame({:#x}, ...{:s}) : Unable to find frame member at {:+#x}. Skipping application of the name ({!r}), type ({!r}), and comment ({!r}) to it.".format('.'.join((__name__, cls.__name__)), ea, tagmap_output, offset, name, type, comment))
                 continue
 
@@ -300,7 +300,7 @@ class apply(object):
             if isinstance(type, basestring):
                 try:
                     member.type = struc.by(type)
-                except LookupError:
+                except internal.exceptions.StructureNotFoundError:
                     logging.warn("{:s}.frame({:#x}, ...{:s}): Unable to find structure {!r} for member at {:+#x}. Skipping it.".format('.'.join((__name__, cls.__name__)), ea, tagmap_output, type, offset))
 
             # otherwise, it's a pythonic tuple that we can just assign

--- a/custom/tags.py
+++ b/custom/tags.py
@@ -127,7 +127,7 @@ class read(object):
 
             # if it's a structure, then the type is the structure name
             if isinstance(member.type, struc.structure_t):
-                logging.info("{:s}.frame({:#x}) : Storing structure-based type as name for field {:+#x} with tne type {!s}.".format('.'.join((__name__, cls.__name__)), ea, member.offset, member.type))
+                logging.debug("{:s}.frame({:#x}) : Storing structure-based type as name for field {:+#x} with tne type {!s}.".format('.'.join((__name__, cls.__name__)), ea, member.offset, member.type))
                 type = member.type.name
 
             # otherwise, the type is a tuple that we can serializer

--- a/misc/tools.py
+++ b/misc/tools.py
@@ -96,8 +96,11 @@ def colormarks(color=0x7f007f):
         database.tag(ea, 'mark', m)
         if database.color(ea) is None:
             database.color(ea, color)
-        try: f.add(func.top(ea))
-        except (LookupError, ValueError): pass
+        try:
+            f.add(func.top(ea))
+        except internal.exceptions.FunctionNotFoundError:
+            pass
+        continue
 
     # tag the functions too
     for ea in list(f):
@@ -157,7 +160,7 @@ def checkmarks():
     for a, m in database.marks():
         try:
             res.append((func.top(a), a, m))
-        except ValueError:
+        except internal.exceptions.FunctionNotFoundError:
             pass
         continue
 
@@ -283,8 +286,8 @@ def makecall(ea=None, target=None):
             left = database.address.prevstack(ea, offset+database.config.bits()/8)
             # FIXME: if left is not an assignment or a push, find last assignment
             result.append((name, left))
-    except LookupError:
-        raise LookupError("{:s}.makecall({!r}, {!r}) : Unable to get arguments for target function.".format(__name__, ea, target))
+    except internal.exceptions.OutOfBoundsError:
+        raise internal.exceptions.OutOfBoundserror("{:s}.makecall({!r}, {!r}) : Unable to get arguments for target function.".format(__name__, ea, target))
 
     # FIXME: replace these crazy list comprehensions with something more comprehensible.
 #    result = ["{:s}={:s}".format(name, instruction.op_repr(ea, 0)) for name, ea in result]

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -34,7 +34,7 @@ import database as _database
 
 def application():
     '''Return the current instance of the IDA Application.'''
-    raise NotImplementedError
+    raise internal.exceptions.MissingMethodError
 
 def ask(string, **default):
     """Ask the user a question providing the option to choose "yes", "no", or "cancel".
@@ -77,7 +77,7 @@ class current(object):
         ea = cls.address()
         res = idaapi.get_func(ea)
         if res is None:
-            raise StandardError("{:s}.function() : Not currently inside a function.".format('.'.join((__name__, cls.__name__))))
+            raise internal.exceptions.FunctionNotFoundError("{:s}.function() : Unable to locate the current function.".format('.'.join((__name__, cls.__name__))))
         return res
     @classmethod
     def segment(cls):
@@ -87,7 +87,7 @@ class current(object):
     @classmethod
     def status(cls):
         '''Return the IDA status.'''
-        raise NotImplementedError
+        raise internal.exceptions.UnsupportedCapability("{:s}.status() : Unable to return the current status of IDA.".format('.'.join((__name__, cls.__name__))))
     @classmethod
     def symbol(cls):
         '''Return the current highlighted symbol name.'''
@@ -99,7 +99,7 @@ class current(object):
         left, right = idaapi.twinpos_t(), idaapi.twinpos_t()
         ok = idaapi.read_selection(view, left, right)
         if not ok:
-            raise StandardError("{:s}.selection() : Unable to read selection.".format('.'.join((__name__, cls.__name__))))
+            raise internal.exceptions.DisassemblerError("{:s}.selection() : Unable to read the current selection.".format('.'.join((__name__, cls.__name__))))
         pl_l, pl_r = left.place(view), right.place(view)
         return _database.address.head(pl_l.ea), _database.address.tail(pl_r.ea)
     @classmethod
@@ -265,7 +265,7 @@ class strings(appwindow):
     @classmethod
     def __on_openidb__(cls, code, is_old_database):
         if code != idaapi.NW_OPENIDB or is_old_database:
-            raise RuntimeError
+            raise internal.exceptions.InvalidParameterError("{:s}.__on_openidb__({:#x}, {:b}) : Hook was called with an unexpected code or an old database.".format('.'.join((__name__, cls.__name__)), code, is_old_database))
         config = idaapi.strwinsetup_t()
         config.minlen = 3
         config.ea1, config.ea2 = idaapi.cvar.inf.minEA, idaapi.cvar.inf.maxEA
@@ -295,7 +295,7 @@ class strings(appwindow):
         string = idaapi.string_info_t()
         res = idaapi.get_strlist_item(index, string)
         if not res:
-            raise RuntimeError("{:s}.at({:d}) : The call to idaapi.get_strlist_item({:d}) returned {!r}.".format('.'.join((__name__, cls.__name__)), index, index, res))
+            raise internal.exceptions.DisassemblerError("{:s}.at({:d}) : The call to idaapi.get_strlist_item({:d}) returned {!r}.".format('.'.join((__name__, cls.__name__)), index, index, res))
         return string
     @classmethod
     def get(cls, index):
@@ -341,7 +341,7 @@ class timer(object):
     @classmethod
     def unregister(cls, id):
         '''Unregister the specified ``id``.'''
-        raise NotImplementedError("{:s}.unregister({!s}) : A lock or a signal s needed here in order to unregister this timer safely.".format('.'.join((__name__, cls.__name__)), id))
+        raise internal.exceptions.UnsupportedCapability("{:s}.unregister({!s}) : A lock or a signal is needed here in order to unregister this timer safely.".format('.'.join((__name__, cls.__name__)), id))
         idaapi.unregister_timer(cls.clock[id])
         del(cls.clock[id])
     @classmethod
@@ -470,7 +470,7 @@ class widget(object):
     @classmethod
     def form(cls, twidget):
         '''Return an IDA plugin form as a UI widget.'''
-        raise NotImplementedError
+        raise internal.exceptions.MissingMethodError
 
 class clipboard(object):
     """
@@ -496,7 +496,7 @@ class mouse(object):
     @classmethod
     def position(cls):
         '''Return the current `(x, y)` position of the cursor.'''
-        raise NotImplementedError
+        raise internal.exceptions.MissingMethodError
 
 class keyboard(object):
     """
@@ -527,7 +527,7 @@ class keyboard(object):
     @classmethod
     def input(cls):
         '''Return the current keyboard input context.'''
-        raise NotImplementedError
+        raise internal.exceptions.MissingMethodError
 
 ### PyQt5-specific functions and namespaces
 ## these can overwrite any of the classes defined above
@@ -558,7 +558,7 @@ try:
         @classmethod
         def input(cls):
             '''Return the current keyboard input context.'''
-            raise NotImplementedError
+            raise internal.exceptions.MissingMethodError
 
     class UIProgress(object):
         """


### PR DESCRIPTION
A number of the exceptions that are thrown have been replaced with custom exceptions. This results in error messages being more obvious about what the actual cause is. Pretty much all the modules needed to be updated, and any explicitly caught exceptions needed to be re-implemented to use the new ones.

Also, some of the error messages were tweaked to try and make them single-sentences, and include all parameters that resulted in the error. Some spaces were added to all comma-separated elements and module imports with the hope that things will be a little bit more readable.