### PR TITLE
requirements.txt: added a reference to the future module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 six==1.10.0
 networkx==1.10
+future==0.16.0


### PR DESCRIPTION
This closes issue #25.

Simply adding a reference to "future" results in the "builtins" module being available.