### PR TITLE
Fixed the issue where externals can be mis-identified as a valid function.

### DIFF
--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1092,6 +1092,19 @@ def addressOfRuntimeOrStatic(func):
         # yep, we're an import
         return True, func
 
+    # check if we're _not_ actually within a function (mis-defined external)
+    if not function.within(fn.startEA):
+        import database
+
+        # ensure that we're an import, otherwise this is definitely not misdefined
+        try:
+            database.imports.at(fn.startEA)
+        except internal.exceptions.MissingTypeOrAttribute:
+            raise internal.exceptions.FunctionNotFoundError(u"{:s}.addressOfRuntimeOrStatic({#x}) : Unable to locate function by address.".format(cls.__name__, fn.startEA))
+
+        # ok, we found a mis-defined import
+        return True, func
+
     # nope, we're just a function
     return False, fn.startEA
 

--- a/base/database.py
+++ b/base/database.py
@@ -1353,7 +1353,7 @@ def tag(ea):
         func = function.by_address(ea)
     except E.FunctionNotFoundError:
         func = None
-    repeatable = False if func else True
+    repeatable = False if func and function.within(ea) else True
 
     # fetch the tags from the repeatable and non-repeatable comment at the given address
     res = comment(ea, repeatable=False)
@@ -1421,7 +1421,7 @@ def tag(ea, key, value):
         func = function.by_address(ea)
     except E.FunctionNotFoundError:
         func = None
-    repeatable = False if func else True
+    repeatable = False if func and function.within(ea) else True
 
     # grab the current tag out of the correct repeatable or non-repeatable comment
     ea = interface.address.inside(ea)
@@ -1431,7 +1431,7 @@ def tag(ea, key, value):
 
     # update the tag's reference if we're actually adding a key and not overwriting it
     if key not in state:
-        if func:
+        if func and function.within(ea):
             internal.comment.contents.inc(ea, key)
         else:
             internal.comment.globals.inc(ea, key)
@@ -1463,7 +1463,7 @@ def tag(ea, key, none):
         func = function.by_address(ea)
     except E.FunctionNotFoundError:
         func = None
-    repeatable = False if func else True
+    repeatable = False if func and function.within(ea) else True
 
     # fetch the dict, remove the key, then write it back.
     state = internal.comment.decode(comment(ea, repeatable=not repeatable))
@@ -1475,7 +1475,7 @@ def tag(ea, key, none):
     comment(ea, internal.comment.encode(state), repeatable=repeatable)
 
     # delete its reference since it's been removed from the dict
-    if func:
+    if func and function.within(ea):
         internal.comment.contents.dec(ea, key)
     else:
         internal.comment.globals.dec(ea, key)

--- a/base/function.py
+++ b/base/function.py
@@ -588,7 +588,7 @@ def within():
 def within(ea):
     '''Return true if the address `ea` is within a function.'''
     ea = interface.address.within(ea)
-    return idaapi.get_func(ea) is not None
+    return idaapi.get_func(ea) is not None and idaapi.segtype(ea) != idaapi.SEG_XTRN
 
 # Checks if ea is contained in function or in any of its chunks
 @utils.multicase()


### PR DESCRIPTION
In some IDBs that IDA makes for ELF files, the symbols inside the "extern" segment will be considered properly defined functions. This can result in `minsc` acting weird in those situations such as when applying/searching tags, or trying to determine how to name the given address.

This was fixed in `function.within()` by checking if the given address is within a segment with the type `idaapi.SEG_XTRN`. If so, then `function.within()` will properly return false. All of the tagging-related functions in the `database` module were also updated to double-check using `function.within()`.

The internal function, `interface.addressOfRuntimeOrStatic()`, needed a check as well. This function also verifies that the address is an actual import by cross-referencing the address with the imports list.

This closes issue #31.