### PR TITLE
internal/utils: fixed the `wrap.assemble()` function to include the wildcard arguments when calculating the code object's stack size.

### DIFF
--- a/base/_utils.py
+++ b/base/_utils.py
@@ -1284,6 +1284,7 @@ class wrap(object):
         # include any wildcard arguments
         for n in Fwildargs:
             asm(cls.co_assemble('LOAD_FAST', co_varnames.index(n)))
+            co_stacksize += 1
 
         # call `wrapper` with the correct call type (+1 for `F`, -1 if bound)
         asm(cls.co_assemble(call, len(Fargs) + 1 - int(bound)))


### PR DESCRIPTION
When wrapping a function with `utils.wrap`, the `assemble()` function forgets to include wildcard arguments when aggregating the stack size. This appears to result in parameters that are pushed onto the stack to be gc'd prior to a code object's instruction actually using it. If this parameter is then passed into a lower-level closure, a scoping issue (use-after-free) will occur.

The symptom is super-unreliable to reproduce, but after integrating the fix in this PR I've been unable to reproduce with any of the fcompose-based utilities in my `.idapythonrc.py` file.

Hopefully this closes issue #37.