### PR TITLE
Updated CONTRIBUTING.md to remove policies that just haven't been honored

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,14 +128,6 @@ The following pull requests are desired:
 * Documentation issues or especially translation to other languages
 * Fixes for any of the issues that are listed in GitHub's issue tracker
 
-## New Versions of IDA (Tags)
-
-If a new version of IDA gets released, a new git tag will be created with
-its name matching the previous version of IDA that the plugin was developed
-against. This is primarily for bisecting against in case something in the
-future gets broken. IDAPython's API is pretty much a moving target so
-we need all the help we can get!
-
 ## Conclusion
 
 Thanks for your interest in contributing to this plugin!


### PR DESCRIPTION
It was pointed out in issue #36 that a number of things haven't been honored during the present lifetime of this project. This PR updates a number of things within the documentation that just aren't relevant anymore as a result.

The documentation is also updated to reference that later versions of IDA are supported and also that at the current moment only Python2 is supported despite this likely changing in the future.

This aims to close the concerns posed by issue #36.