### PR TITLE
Updated documentation to reference latest version of IDA and the Python 2.x requirement for IDAPython

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,9 +25,10 @@ and annotation issues can be performed with just a few lines of code. This
 should enable a user to write quick, hacky, temporary code that can be used
 to augment their reversing endeavors without distraction.
 
-This plugin supports all the different platforms that IDA supports which
-includes Windows, Linux, and MacOS. At the present time, only IDA 6.9 up
-till IDA 7.1.180227 are currently supported.
+This plugin is dependant upon IDAPython with Python 2.x, and supports all of
+the different platforms the IDA supports which includes Windows, Linux, and
+MacOS. At the present time, only IDA 6.9 up till IDA 7.4 are currently
+supported.
 
 Table of Contents
 =================

--- a/docs/static/install.rst
+++ b/docs/static/install.rst
@@ -16,10 +16,11 @@ they have created during their reversing project.
 Software Requirements
 ---------------------
 
-This plugin requires IDA Pro to be installed along with the IDAPython plugin.
-IDA versions 6.9 up to 7.1.180227 are supported. The installation steps
-described within this document assume that you're not using the bundled Python
-instance and have instead installed a Python interpreter separately.
+This plugin requires IDA Pro to be installed along with the IDAPython plugin
+for the Python 2.x series. IDA versions 6.9 up to 7.4 are supported. The
+installation steps described within this document assume that you're not using
+the bundled Python instance and have instead installed a Python 2.x interpreter
+separately.
 
 ----------------------------
 Installing the actual plugin


### PR DESCRIPTION
The documentation references an older version of IDA which can mislead users into believing that the latest version of IDA is unsupported. This is not the case and as such this PR updates the documentation to reference the present version of IDA.

The index and installation pages have also been updated to reference the one hard requirement which is Python 2.x. This is likely to change in the future, but at the present time this should be noted as users are likely migrating to 3.x due to the EOL of the 2.x series.

This is part of PR #39, and aims to fix the concerns posted by issue #36.