### PR TITLE
Update everything mentioned in the IDA 6.x<->7.x porting guide

### DIFF
--- a/base/_comment.py
+++ b/base/_comment.py
@@ -644,19 +644,11 @@ class contents(tagging):
     #btag = idaapi.stag         # XXX: apparently 'S' is used for comments
     btag = idaapi.atag
 
-    if idaapi.__version__ < 7.0:
-        @classmethod
-        def _key(cls, ea):
-            '''Converts the address `ea` to a key that's used to store contents data for the specified function.'''
-            res = idaapi.get_func(ea)
-            return res.startEA if res else None
-
-    else:
-        @classmethod
-        def _key(cls, ea):
-            '''Converts the address `ea` to a key that's used to store contents data for the specified function.'''
-            res = idaapi.get_func(ea)
-            return res.start_ea if res else None
+    @classmethod
+    def _key(cls, ea):
+        '''Converts the address `ea` to a key that's used to store contents data for the specified function.'''
+        res = idaapi.get_func(ea)
+        return internal.interface.range.start(res) if res else None
 
     @classmethod
     def _read_header(cls, target, ea):

--- a/base/_comment.py
+++ b/base/_comment.py
@@ -638,17 +638,25 @@ class contents(tagging):
     """
 
     ## for each function's content
-    # netnode.blob[fn.startEA, btag] = marshal.dumps({'name', 'address'})
-    # netnode.sup[fn.startEA] = marshal.dumps({tagnames})
+    # netnode.blob[fn.start_ea, btag] = marshal.dumps({'name', 'address'})
+    # netnode.sup[fn.start_ea] = marshal.dumps({tagnames})
 
     #btag = idaapi.stag         # XXX: apparently 'S' is used for comments
     btag = idaapi.atag
 
-    @classmethod
-    def _key(cls, ea):
-        '''Converts the address `ea` to a key that's used to store contents data for the specified function.'''
-        res = idaapi.get_func(ea)
-        return res.startEA if res else None
+    if idaapi.__version__ < 7.0:
+        @classmethod
+        def _key(cls, ea):
+            '''Converts the address `ea` to a key that's used to store contents data for the specified function.'''
+            res = idaapi.get_func(ea)
+            return res.startEA if res else None
+
+    else:
+        @classmethod
+        def _key(cls, ea):
+            '''Converts the address `ea` to a key that's used to store contents data for the specified function.'''
+            res = idaapi.get_func(ea)
+            return res.start_ea if res else None
 
     @classmethod
     def _read_header(cls, target, ea):

--- a/base/_declaration.py
+++ b/base/_declaration.py
@@ -71,7 +71,10 @@ def mangledQ(string):
 class extract:
     @staticmethod
     def declaration(string):
-        res = idaapi.demangle_name(internal.utils.string.to(string), idaapi.cvar.inf.long_demnames)
+        if idaapi.__version__ < 7.0:
+            res = idaapi.demangle_name(internal.utils.string.to(string), idaapi.cvar.inf.long_demnames)
+        else:
+            res = idaapi.demangle_name(internal.utils.string.to(string), idaapi.cvar.inf.long_demnames, idaapi.DQT_FULL)
         return string if res is None else internal.utils.string.of(res)
 
     @staticmethod

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1178,20 +1178,21 @@ def addressOfRuntimeOrStatic(func):
         return True, func
 
     # check if we're _not_ actually within a function (mis-defined external)
-    if not function.within(fn.startEA):
+    ea = range.start(fn)
+    if not function.within(ea):
         import database
 
         # ensure that we're an import, otherwise this is definitely not misdefined
         try:
-            database.imports.at(fn.startEA)
+            database.imports.at(ea)
         except internal.exceptions.MissingTypeOrAttribute:
-            raise internal.exceptions.FunctionNotFoundError(u"{:s}.addressOfRuntimeOrStatic({#x}) : Unable to locate function by address.".format(cls.__name__, fn.startEA))
+            raise internal.exceptions.FunctionNotFoundError(u"{:s}.addressOfRuntimeOrStatic({#x}) : Unable to locate function by address.".format(cls.__name__, ea))
 
         # ok, we found a mis-defined import
         return True, func
 
     # nope, we're just a function
-    return False, fn.startEA
+    return False, ea
 
 ## internal enumerations that idapython missed
 class fc_block_type_t:

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -620,15 +620,15 @@ class node(object):
 
         # XXX: implement a parser for type_t in order to figure out idaapi.BT_COMPLEX types
         # return type_t
-        data = next(iterable)
+        data = six.next(iterable)
         base, flags, mods = six.byte2int(data) & idaapi.TYPE_BASE_MASK, six.byte2int(data) & idaapi.TYPE_FLAGS_MASK, six.byte2int(data) & idaapi.TYPE_MODIF_MASK
         if base == idaapi.BT_PTR:
-            data+= next(iterable)
+            data+= six.next(iterable)
         elif base == idaapi.BT_COMPLEX and flags == 0x30:
-            by = next(iterable)
+            by = six.next(iterable)
             skip, data = six.byte2int(by), data + by
             while skip > 1:
-                data+= next(iterable)
+                data+= six.next(iterable)
                 skip -= 1
         elif base in {idaapi.BT_ARRAY, idaapi.BT_FUNC, idaapi.BT_COMPLEX, idaapi.BT_BITFIELD}:
             lookup = { getattr(idaapi, name) : "idaapi.{:s}".format(name) for name in dir(idaapi) if name.startswith('BT_') }
@@ -699,7 +699,7 @@ class node(object):
         def id64(sup):
             iterable = iter(sup)
             #chunks = zip(*((iter(sup),)*3))
-            length = le((next(iterable), next(iterable), next(iterable)))
+            length = le((six.next(iterable), six.next(iterable), six.next(iterable)))
             chunks = zip(*((iterable,)*5))
             #length = le(chunks.pop(0))
             if len(chunks) != length:
@@ -759,7 +759,7 @@ class namedtypedtuple(tuple):
         '''Return the type for the field `name`.'''
         res = (t for n, t in zip(cls._fields, cls._types) if n == name)
         try:
-            result = next(res)
+            result = six.next(res)
         except StopIteration:
             raise NameError("Unable to locate the type for an unknown field {!r}.".format(name))
         return result
@@ -1143,7 +1143,7 @@ def xiterate(ea, start, next):
     addr = start(ea)
     while addr != idaapi.BADADDR:
         yield addr
-        addr = next(ea, addr)
+        addr = six.next(ea, addr)
     return
 
 def addressOfRuntimeOrStatic(func):
@@ -1307,8 +1307,9 @@ class architecture_t(object):
         else:
             dtype_by_size = idaapi.get_dtype_by_size
 
-        dtype = next((kwargs[n] for n in ('dtyp', 'dtype', 'type') if n in kwargs), idaapi.dt_bitfield if bits == 1 else dtype_by_size(bits // 8))
         #dtyp = kwargs.get('dtyp', idaapi.dt_bitfild if bits == 1 else dtype_by_size(bits//8))
+        dtype = six.next((kwargs[n] for n in ('dtyp', 'dtype', 'type') if n in kwargs), idaapi.dt_bitfield if bits == 1 else dtype_by_size(bits // 8))
+
         namespace = dict(register_t.__dict__)
         namespace.update({'__name__':name, '__parent__':None, '__children__':{}, '__dtype__':dtype, '__position__':0, '__size__':bits})
         namespace['realname'] = idaname
@@ -1329,7 +1330,7 @@ class architecture_t(object):
         else:
             dtype_by_size = idaapi.get_dtype_by_size
 
-        dtype = next((kwargs[n] for n in ('dtyp', 'dtype', 'type') if n in kwargs), idaapi.dt_bitfield if bits == 1 else dtype_by_size(bits // 8))
+        dtype = six.next((kwargs[n] for n in ('dtyp', 'dtype', 'type') if n in kwargs), idaapi.dt_bitfield if bits == 1 else dtype_by_size(bits // 8))
         #dtyp = kwargs.get('dtyp', idaapi.dt_bitfild if bits == 1 else dtype_by_size(bits//8))
         namespace = dict(register_t.__dict__)
         namespace.update({'__name__':name, '__parent__':parent, '__children__':{}, '__dtype__':dtype, '__position__':position, '__size__':bits})

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1143,7 +1143,7 @@ def xiterate(ea, start, next):
     addr = start(ea)
     while addr != idaapi.BADADDR:
         yield addr
-        addr = six.next(ea, addr)
+        addr = next(ea, addr)
     return
 
 def addressOfRuntimeOrStatic(func):

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1034,7 +1034,7 @@ class switch_t(object):
     def register(self):
         '''Return the register that the switch is based on.'''
         import instruction
-        ri, rt = self.object.regnum, self.object.regdtyp
+        ri, rt = (self.object.regnum, self.object.regdtyp) if idaapi.__version__ < 7.0 else (self.object.regnum, self.object.regdtype)
         return instruction.architecture.by_indextype(ri, rt)
     @property
     def base(self):

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1247,7 +1247,7 @@ class architecture_t(object):
             dtype_by_size = internal.utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int)
         # newer
         else:
-            dtype_by_size = idaapi.get_dtyp_by_size
+            dtype_by_size = idaapi.get_dtype_by_size
 
         dtype = next((kwargs[n] for n in ('dtyp', 'dtype', 'type') if n in kwargs), idaapi.dt_bitfield if bits == 1 else dtype_by_size(bits // 8))
         #dtyp = kwargs.get('dtyp', idaapi.dt_bitfild if bits == 1 else dtype_by_size(bits//8))
@@ -1269,7 +1269,7 @@ class architecture_t(object):
             dtype_by_size = internal.utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int)
         # newer
         else:
-            dtype_by_size = idaapi.get_dtyp_by_size
+            dtype_by_size = idaapi.get_dtype_by_size
 
         dtyp = kwargs.get('dtyp', idaapi.dt_bitfild if bits == 1 else dtype_by_size(bits//8))
         namespace = dict(register_t.__dict__)
@@ -1310,7 +1310,7 @@ class architecture_t(object):
 
     def by_indexsize(self, index, size):
         '''Lookup a register according to its `index` and `size`.'''
-        dtype_by_size = internal.utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int) if idaapi.__version__ < 7.0 else idaapi.get_dtyp_by_size
+        dtype_by_size = internal.utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int) if idaapi.__version__ < 7.0 else idaapi.get_dtype_by_size
         dtype = dtype_by_size(size)
         return self.by_indextype(index, dtype)
     def promote(self, register, size=None):

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1273,15 +1273,16 @@ class architecture_t(object):
         else:
             dtype_by_size = idaapi.get_dtype_by_size
 
-        dtyp = kwargs.get('dtyp', idaapi.dt_bitfild if bits == 1 else dtype_by_size(bits//8))
+        dtype = next((kwargs[n] for n in ('dtyp', 'dtype', 'type') if n in kwargs), idaapi.dt_bitfield if bits == 1 else dtype_by_size(bits // 8))
+        #dtyp = kwargs.get('dtyp', idaapi.dt_bitfild if bits == 1 else dtype_by_size(bits//8))
         namespace = dict(register_t.__dict__)
-        namespace.update({'__name__':name, '__parent__':parent, '__children__':{}, '__dtype__':dtyp, '__position__':position, '__size__':bits})
+        namespace.update({'__name__':name, '__parent__':parent, '__children__':{}, '__dtype__':dtype, '__position__':position, '__size__':bits})
         namespace['realname'] = idaname
         namespace['alias'] = kwargs.get('alias', set())
         namespace['architecture'] = self
         res = type(name, (register_t,), namespace)()
         self.__register__.__state__[name] = res
-        self.__cache__[idaname or name, dtyp] = name
+        self.__cache__[idaname or name, dtype] = name
         parent.__children__[position] = res
         return res
 

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -85,25 +85,26 @@ class netnode(object):
 
     # now to fix up the version skew as a result of IDA 7.0
     if idaapi.__version__ < 7.0:
-        sup1st = _ida_netnode.netnode_sup1st if idaapi.__version__ < 7.0 else _ida_netnode.netnode_supfirst
-        supnxt = _ida_netnode.netnode_supnxt if idaapi.__version__ < 7.0 else _ida_netnode.netnode_supnext
-        hashnxt = _ida_netnode.netnode_hashnxt if idaapi.__version__ < 7.0 else _ida_netnode.netnode_hashnext
-        hash1st = _ida_netnode.netnode_hash1st if idaapi.__version__ < 7.0 else _ida_netnode.netnode_hashfirst
-        char1st = _ida_netnode.netnode_char1st if idaapi.__version__ < 7.0 else _ida_netnode.netnode_charfirst
-        charnxt = _ida_netnode.netnode_charnxt if idaapi.__version__ < 7.0 else _ida_netnode.netnode_charnext
-        name = _ida_netnode.netnode_name if idaapi.__version__ < 7.0 else _ida_netnode.netnode_get_name
-        alt1st = _ida_netnode.netnode_alt1st if idaapi.__version__ < 7.0 else _ida_netnode.netnode_altfirst
-        altnxt = _ida_netnode.netnode_altnxt if idaapi.__version__ < 7.0 else _ida_netnode.netnode_altnext
+        supfirst = _ida_netnode.netnode_sup1st
+        supnext = _ida_netnode.netnode_supnxt
+        hashnext = _ida_netnode.netnode_hashnxt
+        hashfirst = _ida_netnode.netnode_hash1st
+        charfirst = _ida_netnode.netnode_char1st
+        charnext = _ida_netnode.netnode_charnxt
+        name = _ida_netnode.netnode_name
+        altfirst = _ida_netnode.netnode_alt1st
+        altnext = _ida_netnode.netnode_altnxt
+
     else:   # >= 7.0
-        sup1st = _ida_netnode.netnode_supfirst
-        supnxt = _ida_netnode.netnode_supnext
-        hashnxt = _ida_netnode.netnode_hashnext
-        hash1st = _ida_netnode.netnode_hashfirst
-        char1st = _ida_netnode.netnode_charfirst
-        charnxt = _ida_netnode.netnode_charnext
+        supfirst = _ida_netnode.netnode_supfirst
+        supnext = _ida_netnode.netnode_supnext
+        hashnext = _ida_netnode.netnode_hashnext
+        hashfirst = _ida_netnode.netnode_hashfirst
+        charfirst = _ida_netnode.netnode_charfirst
+        charnext = _ida_netnode.netnode_charnext
         name = _ida_netnode.netnode_get_name
-        alt1st = _ida_netnode.netnode_altfirst
-        altnxt = _ida_netnode.netnode_altnext
+        altfirst = _ida_netnode.netnode_altfirst
+        altnext = _ida_netnode.netnode_altnext
 
 class utils(object):
     @classmethod
@@ -189,45 +190,45 @@ class utils(object):
 
     @classmethod
     def falt(cls, node):
-        for res in cls.valfiter(node, netnode.alt1st, netnode.altlast, netnode.altnxt, netnode.altval):
+        for res in cls.valfiter(node, netnode.altfirst, netnode.altlast, netnode.altnext, netnode.altval):
             yield res
         return
     @classmethod
     def ralt(cls, node):
-        for res in cls.valriter(node, netnode.alt1st, netnode.altprev, netnode.altnxt, netnode.altval):
+        for res in cls.valriter(node, netnode.altfirst, netnode.altprev, netnode.altnext, netnode.altval):
             yield res
         return
 
     @classmethod
     def fsup(cls, node):
-        for res in cls.valfiter(node, netnode.sup1st, netnode.suplast, netnode.supnxt, netnode.supval):
+        for res in cls.valfiter(node, netnode.supfirst, netnode.suplast, netnode.supnext, netnode.supval):
             yield res
         return
     @classmethod
     def rsup(cls, node):
-        for res in cls.valriter(node, netnode.sup1st, netnode.supprev, netnode.supnxt, netnode.supval):
+        for res in cls.valriter(node, netnode.supfirst, netnode.supprev, netnode.supnext, netnode.supval):
             yield res
         return
 
     @classmethod
     def fhash(cls, node):
-        for res in cls.hfiter(node, netnode.hash1st, netnode.hashlast, netnode.hashnxt, netnode.hashval):
+        for res in cls.hfiter(node, netnode.hashfirst, netnode.hashlast, netnode.hashnext, netnode.hashval):
             yield res
         return
     @classmethod
     def rhash(cls, node):
-        for res in cls.hriter(node, netnode.hash1st, netnode.hashprev, netnode.hashnxt, netnode.hashval):
+        for res in cls.hriter(node, netnode.hashfirst, netnode.hashprev, netnode.hashnext, netnode.hashval):
             yield res
         return
 
     @classmethod
     def fchar(cls, node):
-        for res in cls.valfiter(node, netnode.char1st, netnode.charlast, netnode.charnxt, netnode.charval):
+        for res in cls.valfiter(node, netnode.charfirst, netnode.charlast, netnode.charnext, netnode.charval):
             yield res
         return
     @classmethod
     def rchar(cls, node):
-        for res in cls.valriter(node, netnode.char1st, netnode.charprev, netnode.charnxt, netnode.charval):
+        for res in cls.valriter(node, netnode.charfirst, netnode.charprev, netnode.charnext, netnode.charval):
             yield res
         return
 

--- a/base/database.py
+++ b/base/database.py
@@ -1949,7 +1949,7 @@ class address(object):
             nextea = cls.next(ea)
 
             ## XXX: it seems that idaapi.is_basic_block_end requires the following to be called
-            # idaapi.decode_insn(ea)
+            # idaapi.decode_insn(insn, ea)
             ## XXX: for some reason is_basic_block_end will occasionally include some stray 'call' instructions
             # if idaapi.is_basic_block_end(ea):
             #     yield block, nextea
@@ -4198,7 +4198,10 @@ class set(object):
     @classmethod
     def code(cls, ea):
         '''Set the data at address `ea` to code.'''
-        return idaapi.create_insn(ea)
+        if idaapi.__version__ < 7.0:
+            return idaapi.create_insn(ea)
+        res = idaapi.insn_t()
+        return idaapi.create_insn(res, ea)
 
     @utils.multicase(size=six.integer_types)
     @classmethod

--- a/base/database.py
+++ b/base/database.py
@@ -4791,8 +4791,9 @@ class get(object):
         # long-numerics so we can read them
         if any(hasattr(idaapi, name) for name in {'FF_QWRD', 'FF_QWORD'}):
             name = six.next(name for name in {'FF_QWRD', 'FF_QWORD'} if hasattr(idaapi, name))
-            if getattr(idaapi, name) not in numerics:
-                lnumerics[idaapi.FF_QWRD] = 8
+            value = getattr(idaapi, name)
+            if value not in numerics:
+                lnumerics[value] = 8
             pass
 
         # FF_OWORD, FF_YWORD and FF_ZWORD might not exist in older versions

--- a/base/database.py
+++ b/base/database.py
@@ -4202,7 +4202,12 @@ class set(object):
         '''Set the data at address `ea` to code.'''
         if idaapi.__version__ < 7.0:
             return idaapi.create_insn(ea)
+
         res = idaapi.insn_t()
+        try:
+            return idaapi.create_insn(ea, res)
+        except TypeError:
+            pass
         return idaapi.create_insn(res, ea)
 
     @utils.multicase(size=six.integer_types)

--- a/base/database.py
+++ b/base/database.py
@@ -3072,11 +3072,11 @@ class type(object):
         @utils.multicase(ea=six.integer_types)
         def __new__(cls, ea):
             '''Return the `[type, length]` of the array at the address specified by `ea`.'''
-            F, op, cb = type.flags(ea), idaapi.opinfo_t(), idaapi.get_item_size(ea)
+            F, ti, cb = type.flags(ea), idaapi.opinfo_t(), idaapi.get_item_size(ea)
 
             # get the opinfo at the current address to verify if there's a structure or not
-            ok = idaapi.get_opinfo(op, ea, 0, F)
-            tid = op.tid if ok else idaapi.BADADDR
+            ok = idaapi.get_opinfo(ea, 0, F, ti) if idaapi.__version__ < 7.0 else idaapi.get_opinfo(ti, ea, 0, F)
+            tid = ti.tid if ok else idaapi.BADADDR
 
             # convert it to a pythonic type
             res = interface.typemap.dissolve(F, tid, cb)
@@ -3181,7 +3181,7 @@ class type(object):
                 raise E.MissingTypeOrAttribute(u"{:s}.id({:#x}) : The type at specified addresss is not an FF_STRUCT({:#x}) and is instead {:#x}.".format('.'.join((__name__, 'type', 'structure')), ea, FF_STRUCT, res))
 
             ti, F = idaapi.opinfo_t(), type.flags(ea)
-            res = idaapi.get_opinfo(ea, 0, F, ti)
+            res = idaapi.get_opinfo(ea, 0, F, ti) if idaapi.__version__ < 7.0 else idaapi.get_opinfo(ti, ea, 0, F)
             if not res:
                 raise E.DisassemblerError(u"{:s}.id({:#x}) : The call to `idaapi.get_opinfo()` failed at {:#x}.".format('.'.join((__name__, 'type', 'structure')), ea, ea))
             return ti.tid

--- a/base/database.py
+++ b/base/database.py
@@ -282,16 +282,16 @@ class functions(object):
 
         # find first function chunk
         ch = idaapi.get_fchunk(left) or idaapi.get_next_fchunk(left)
-        while ch and ch.startEA < right and (ch.flags & idaapi.FUNC_TAIL) != 0:
-            ui.navigation.procedure(ch.startEA)
-            ch = idaapi.get_next_fchunk(ch.startEA)
+        while ch and interface.range.start(ch) < right and (ch.flags & idaapi.FUNC_TAIL) != 0:
+            ui.navigation.procedure(interface.range.start(ch))
+            ch = idaapi.get_next_fchunk(interface.range.start(ch))
 
         # iterate through the rest of the functions in the database
-        while ch and ch.startEA < right:
-            ui.navigation.procedure(ch.startEA)
-            if function.within(ch.startEA):
-                yield ch.startEA
-            ch = idaapi.get_next_func(ch.startEA)
+        while ch and interface.range.start(ch) < right:
+            ui.navigation.procedure(interface.range.start(ch))
+            if function.within(interface.range.start(ch)):
+                yield interface.range.start(ch)
+            ch = idaapi.get_next_func(interface.range.start(ch))
         return
 
     @utils.multicase(string=basestring)
@@ -436,7 +436,7 @@ class segments(object):
     def __new__(cls):
         '''Yield the bounds of each segment within the current database.'''
         for seg in segment.__iterate__():
-            yield interface.bounds_t(seg.startEA, seg.endEA)
+            yield interface.range.bounds(seg)
         return
 
     @utils.multicase(name=basestring)
@@ -950,7 +950,7 @@ def name(ea, **flags):
     # figure out which name function to call
     if idaapi.__version__ < 6.8:
         # if get_true_name is going to return the function's name instead of a real one, then leave it as unnamed.
-        if fn and fn.startEA == ea and not flags:
+        if fn and interface.range.start(fn) == ea and not flags:
             return None
 
         aname = idaapi.get_true_name(ea) or idaapi.get_true_name(ea, ea)
@@ -1019,7 +1019,7 @@ def name(ea, string, *suffix, **flags):
         # check if our address does not point to a function beginning and if
         # our visible name does not match the requested one. If so, then this
         # might be a switch/jmptable of some sort that needs to be removed.
-        if func.startEA != ea and idaapi.get_visible_name(ea) != string:
+        if interface.range.start(func) != ea and idaapi.get_visible_name(ea) != string:
             idaapi.del_global_name(ea)
         return res
 

--- a/base/function.py
+++ b/base/function.py
@@ -990,6 +990,8 @@ class block(object):
 
         If the color `frame` is specified, set the frame to the specified color.
         """
+        set_node_info = idaapi.set_node_info2 if idaapi.__version__ < 7.0 else idaapi.set_node_info
+
         res, fn, bb = cls.color(ea), by_address(ea), cls.id(ea)
         ni = idaapi.node_info_t()
 
@@ -1004,7 +1006,7 @@ class block(object):
 
         # set the node
         f = (idaapi.NIF_BG_COLOR|idaapi.NIF_FRAME_COLOR) if frame else idaapi.NIF_BG_COLOR
-        try: idaapi.set_node_info2(fn.startEA, bb, ni, f)
+        try: set_node_info(fn.startEA, bb, ni, f)
         finally: idaapi.refresh_idaview_anyway()
 
         # update the color of each item too
@@ -1016,6 +1018,7 @@ class block(object):
     @classmethod
     def color(cls, bb, rgb, **frame):
         '''Sets the color of the basic block `bb` to `rgb`.'''
+        set_node_info = idaapi.set_node_info2 if idaapi.__version__ < 7.0 else idaapi.set_node_info
         res, fn, ni = cls.color(bb), by_address(bb.startEA), idaapi.node_info_t()
 
         # specify the bg color
@@ -1029,7 +1032,7 @@ class block(object):
 
         # set the node
         f = (idaapi.NIF_BG_COLOR|idaapi.NIF_FRAME_COLOR) if frame else idaapi.NIF_BG_COLOR
-        try: idaapi.set_node_info2(fn.startEA, bb.id, ni, f)
+        try: set_node_info(fn.startEA, bb.id, ni, f)
         finally: idaapi.refresh_idaview_anyway()
 
         # update the colors of each item too.
@@ -1701,9 +1704,10 @@ def switches():
 @utils.multicase()
 def switches(func):
     '''Yield each switch found in the function identifed by `func`.'''
+    get_switch_info = idaapi.get_switch_info_ex if idaapi.__version__ < 7.0 else idaapi.get_switch_info
     for ea in iterate(func):
-        res = idaapi.get_switch_info_ex(ea)
-        if res: yield interface.switch_t(res)
+        si = get_switch_info(ea)
+        if si: yield interface.switch_t(si)
     return
 
 class type(object):

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -991,7 +991,7 @@ class operand_types:
     def register(ea, op):
         '''Operand type decoder for ``idaapi.o_reg`` which returns a ``register_t``.'''
         global architecture
-        dtype_by_size = utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int) if idaapi.__version__ < 7.0 else idaapi.get_dtyp_by_size
+        dtype_by_size = utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int) if idaapi.__version__ < 7.0 else idaapi.get_dtype_by_size
         if op.type in {idaapi.o_reg}:
             res, dt = op.reg, dtype_by_size(database.config.bits()//8)
             return architecture.by_indextype(res, op.dtyp)
@@ -1122,7 +1122,7 @@ class operand_types:
         scale = scale_lookup[F2 & 0xc0]
 
         bits = database.config.bits()
-        dtype_by_size = utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int) if idaapi.__version__ < 7.0 else idaapi.get_dtyp_by_size
+        dtype_by_size = utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int) if idaapi.__version__ < 7.0 else idaapi.get_dtype_by_size
 
         seg, sel = (op.specval & 0xffff0000) >> 16, (op.specval & 0x0000ffff) >> 0
 

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -977,7 +977,7 @@ class type(object):
     def is_call(cls, ea):
         '''Returns true if the instruction at `ea` is a call.'''
         ea = interface.address.inside(ea)
-        if hasattr(idaapi, 'is_call_insn'):
+        if idaapi.__version__ < 7.0 and hasattr(idaapi, 'is_call_insn'):
             idaapi.decode_insn(ea)
             return idaapi.is_call_insn(ea)
 

--- a/base/segment.py
+++ b/base/segment.py
@@ -210,7 +210,7 @@ def iterate(segment):
 @utils.multicase(segment=idaapi.segment_t)
 def iterate(segment):
     '''Iterate through all of the addresses within the ``idaapi.segment_t`` represented by `segment`.'''
-    for ea in database.address.iterate(interface.range.start(segment), interface.range.end(segment)):
+    for ea in database.address.iterate(*interface.range.unpack(segment)):
         yield ea
     return
 
@@ -220,12 +220,12 @@ def size():
     seg = ui.current.segment()
     if seg is None:
         raise E.SegmentNotFoundError(u"{:s}.size() : Unable to locate the current segment.".format(__name__))
-    return interface.address.size(seg)
+    return interface.range.size(seg)
 @utils.multicase()
 def size(segment):
     '''Return the size of the segment specified by `segment`.'''
     seg = by(segment)
-    return interface.address.size(seg)
+    return interface.range.size(seg)
 
 @utils.multicase()
 def offset():
@@ -260,14 +260,14 @@ def read():
     seg = ui.current.segment()
     if seg is None:
         raise E.SegmentNotFoundError(u"{:s}.read() : Unable to locate the current segment.".format(__name__))
-    return get_bytes(interface.range.start(seg), interface.address.size(seg))
+    return get_bytes(interface.range.start(seg), interface.range.size(seg))
 @utils.multicase()
 def read(segment):
     '''Return the contents of the segment identified by `segment`.'''
     get_bytes = idaapi.get_many_bytes if idaapi.__version__ < 7.0 else idaapi.get_bytes
 
     seg = by(segment)
-    return get_bytes(interface.range.start(seg), interface.address.size(seg))
+    return get_bytes(interface.range.start(seg), interface.range.size(seg))
 string = utils.alias(read)
 
 @utils.multicase()
@@ -283,7 +283,7 @@ def repr(segment):
     get_segment_name = idaapi.get_segm_name if hasattr(idaapi, 'get_segm_name') else idaapi.get_true_segm_name
 
     seg = by(segment)
-    return "{:s} {:s} {:#x}-{:#x} ({:+#x})".format(object.__repr__(seg), get_segment_name(seg), interface.range.start(seg), interface.range.end(seg), interface.address.size(seg))
+    return "{:s} {:s} {:#x}-{:#x} ({:+#x})".format(object.__repr__(seg), get_segment_name(seg), interface.range.start(seg), interface.range.end(seg), interface.range.size(seg))
 
 @utils.multicase()
 def top():

--- a/base/segment.py
+++ b/base/segment.py
@@ -250,15 +250,19 @@ goof = gooffset = gotooffset = goto_offset = utils.alias(go_offset)
 @utils.multicase()
 def read():
     '''Return the contents of the current segment.'''
+    get_bytes = idaapi.get_many_bytes if idaapi.__version__ < 7.0 else idaapi.get_bytes
+
     segment = ui.current.segment()
     if segment is None:
         raise E.SegmentNotFoundError(u"{:s}.read() : Unable to locate the current segment.".format(__name__))
-    return idaapi.get_many_bytes(segment.startEA, segment.endEA-segment.startEA)
+    return get_bytes(segment.startEA, segment.endEA - segment.startEA)
 @utils.multicase()
 def read(segment):
     '''Return the contents of the segment identified by `segment`.'''
+    get_bytes = idaapi.get_many_bytes if idaapi.__version__ < 7.0 else idaapi.get_bytes
+
     seg = by(segment)
-    return idaapi.get_many_bytes(seg.startEA, seg.endEA-seg.startEA)
+    return get_bytes(seg.startEA, seg.endEA - seg.startEA)
 string = utils.alias(read)
 
 @utils.multicase()

--- a/base/segment.py
+++ b/base/segment.py
@@ -210,7 +210,7 @@ def iterate(segment):
 @utils.multicase(segment=idaapi.segment_t)
 def iterate(segment):
     '''Iterate through all of the addresses within the ``idaapi.segment_t`` represented by `segment`.'''
-    for ea in database.address.iterate(interface.range.start(segment), inteface.address.right(segment)):
+    for ea in database.address.iterate(interface.range.start(segment), interface.range.end(segment)):
         yield ea
     return
 

--- a/base/structure.py
+++ b/base/structure.py
@@ -1356,7 +1356,7 @@ class member_t(object):
     def typeinfo(self):
         '''Return the type info of the member.'''
         ti = idaapi.tinfo_t()
-        ok = idaapi.get_or_guess_member_tinfo2(self.ptr, ti) if idaapi.__version__ < 7.0 else idaapi.get_or_guess_member_tinfo2(ti, self.ptr)
+        ok = idaapi.get_or_guess_member_tinfo2(self.ptr, ti) if idaapi.__version__ < 7.0 else idaapi.get_or_guess_member_tinfo(ti, self.ptr)
         if not ok:
             cls = self.__class__
             logging.fatal(u"{:s}.instance({!r}).member({:s}).typeinfo : Unable to determine `idaapi.tinfo_t()` for member {:#x}.".format('.'.join((__name__, cls.__name__)), self.__owner.name, self.name, self.id))

--- a/base/structure.py
+++ b/base/structure.py
@@ -1355,12 +1355,12 @@ class member_t(object):
     @type.getter
     def typeinfo(self):
         '''Return the type info of the member.'''
-        res = idaapi.tinfo_t()
-        ok = idaapi.get_or_guess_member_tinfo2(self.ptr, res)
+        ti = idaapi.tinfo_t()
+        ok = idaapi.get_or_guess_member_tinfo2(self.ptr, ti) if idaapi.__version__ < 7.0 else idaapi.get_or_guess_member_tinfo2(ti, self.ptr)
         if not ok:
             cls = self.__class__
-            logging.fatal(u"{:s}.instance({!r}).member({:s}).typeinfo : Unable to determine `idaapi.tinfo_t()` for member {:#x}.".format('.'.join((__name__,cls.__name__)), self.__owner.name, self.name, self.id))
-        return res
+            logging.fatal(u"{:s}.instance({!r}).member({:s}).typeinfo : Unable to determine `idaapi.tinfo_t()` for member {:#x}.".format('.'.join((__name__, cls.__name__)), self.__owner.name, self.name, self.id))
+        return ti
 
     def __repr__(self):
         '''Display the member in a readable format.'''

--- a/base/structure.py
+++ b/base/structure.py
@@ -1374,6 +1374,7 @@ class member_t(object):
         If `opnum` is defined, then the instruction at the returned `address` references a field that contains the specified structure.
         """
         mid = self.id
+        FF_STRUCT = idaapi.FF_STRUCT if hasattr(idaapi, 'FF_STRUCT') else idaapi.FF_STRU
 
         # calculate the high-byte which is used to determine an address from a structure
         bits = math.trunc(math.ceil(math.log(idaapi.BADADDR)/math.log(2.0)))
@@ -1476,7 +1477,7 @@ class member_t(object):
                     # align the offset, and check if our address is using one
                     # of our structure identifiers
                     offset = interface.address.head(offset, silent=True)
-                    if database.type.flags(offset, idaapi.DT_TYPE) == idaapi.FF_STRU and database.type.structure.id(offset) in identifiers:
+                    if database.type.flags(offset, idaapi.DT_TYPE) == FF_STRUCT and database.type.structure.id(offset) in identifiers:
                         res.append(interface.OREF(ea, opnum, interface.ref_t.of(t)))
                     continue
                 continue

--- a/custom/delphi.py
+++ b/custom/delphi.py
@@ -17,7 +17,7 @@ def string(ea):
     if db.get.i.uint32_t(ea - 8) == 0xffffffff:
         db.set.undefined(ea)
         db.set.integer.dword(ea - 8)
-        cb = db.set.string(ea - 4, type=idaapi.ASCSTR_LEN4)
+        cb = db.set.string(ea - 4, type=idaapi.STRTYPE_LEN4)
         try:
             al = db.set.align(ea - 4 + cb, alignment=8)
         except TypeError:

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -506,7 +506,7 @@ def func_tail_appended(pfn, tail):
 def removing_func_tail(pfn, tail):
     global State
     if State != state.ready: return
-    # tail = area_t
+    # tail = range_t
     for ea in database.address.iterate(tail.startEA, tail.endEA):
         for k in database.tag(ea):
             internal.comment.contents.dec(ea, k, target=pfn.startEA)

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -521,7 +521,7 @@ def removing_func_tail(pfn, tail):
         for k in database.tag(ea):
             internal.comment.contents.dec(ea, k, target=interface.range.start(pfn))
             internal.comment.globals.inc(ea, k)
-            logging.debug(u"{:s}.removing_func_tail({:#x}, {:#x}) : Exchanging (increasing) refcount for global tag {!s} and (decreasing) refcount for contents tag {!s}.".format(__name__, interface.range.start(pfn), interface.range.start(tail), utils.string.repr(k)))
+            logging.debug(u"{:s}.removing_func_tail({:#x}, {:#x}) : Exchanging (increasing) refcount for global tag {!s} and (decreasing) refcount for contents tag {!s}.".format(__name__, interface.range.start(pfn), interface.range.start(tail), utils.string.repr(k), utils.string.repr(k)))
         continue
     return
 

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -99,7 +99,7 @@ class current(object):
         res = idaapi.get_highlight(viewer)
         if res and res[1]:
             return res[0]
-        return rese
+        return res
     @classmethod
     def selection(cls):
         '''Return the current address range of whatever is selected'''

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -91,7 +91,15 @@ class current(object):
     @classmethod
     def symbol(cls):
         '''Return the current highlighted symbol name.'''
-        return idaapi.get_highlighted_identifier()
+        if idaapi.__version__ < 7.0:
+            return idaapi.get_highlighted_identifier()
+
+        # IDA 7.0 way of getting the currently selected text
+        viewer = idaapi.get_current_viewer()
+        res = idaapi.get_highlight(viewer)
+        if res and res[1]:
+            return res[0]
+        return rese
     @classmethod
     def selection(cls):
         '''Return the current address range of whatever is selected'''

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -277,7 +277,14 @@ class strings(appwindow):
         config.only_7bit = True
         config.ignore_heads = False
 
-        res = [idaapi.ASCSTR_TERMCHR, idaapi.ASCSTR_PASCAL, idaapi.ASCSTR_LEN2, idaapi.ASCSTR_UNICODE, idaapi.ASCSTR_LEN4, idaapi.ASCSTR_ULEN2, idaapi.ASCSTR_ULEN4]
+        # aggregate all the string types for IDA 6.95x
+        if idaapi.__version__ < 7.0:
+            res = [idaapi.ASCSTR_TERMCHR, idaapi.ASCSTR_PASCAL, idaapi.ASCSTR_LEN2, idaapi.ASCSTR_UNICODE, idaapi.ASCSTR_LEN4, idaapi.ASCSTR_ULEN2, idaapi.ASCSTR_ULEN4]
+
+        # otherwise use IDA 7.x's naming scheme
+        else:
+            res = [idaapi.STRTYPE_TERMCHR, idaapi.STRTYPE_PASCAL, idaapi.STRTYPE_LEN2, idaapi.STRTYPE_C_16, idaapi.STRTYPE_LEN4, idaapi.STRTYPE_LEN2_16, idaapi.STRTYPE_LEN4_16]
+
         config.strtypes = reduce(lambda t, c: t | (2**c), res, 0)
         if not idaapi.set_strlist_options(config):
             raise internal.exceptions.DisassemblerError(u"{:s}.__on_openidb__({:#x}, {:b}) : Unable to set the default options for the string list.".format('.'.join((__name__, cls.__name__)), code, is_old_database))


### PR DESCRIPTION
IDA 7.4 turns off 6.x compatibility by default which breaks most of the api used by `minsc`. Because of this the user must essentially re-enable 6.x compatibility by modifying their user configuration (or `cfg/python.cfg`). This quirk isn't documented by `minsc`, and so this can be confusing to some people as the docs (recently) claim that IDA 7.4 is supported.

This PR follows the entire porting guide (https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml) and does this by conditionally checking which version of IDA's api to use based on the version that's available and whether or not compatibility mode is enabled.

This should close issue #42, and should also remove the need for writing documentation on how to  re-enable compatibility mode.