### PR TITLE
Updated the most recent version of IDA to IDA 7.4.191112 (SP1).

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,8 +27,8 @@ to augment their reversing endeavors without distraction.
 
 This plugin is dependant upon IDAPython with Python 2.x, and supports all of
 the different platforms the IDA supports which includes Windows, Linux, and
-MacOS. At the present time, only IDA 6.8 up till IDA 7.4 are currently
-supported.
+MacOS. At the present time, only IDA 6.8 up till IDA 7.4.191112 (SP1) are
+currently supported.
 
 Table of Contents
 =================

--- a/docs/static/install.rst
+++ b/docs/static/install.rst
@@ -17,10 +17,10 @@ Software Requirements
 ---------------------
 
 This plugin requires IDA Pro to be installed along with the IDAPython plugin
-for the Python 2.x series. IDA versions 6.8 up to 7.4 are supported. The
-installation steps described within this document assume that you're not using
-the bundled Python instance and have instead installed a Python 2.x interpreter
-separately.
+for the Python 2.x series. IDA versions 6.8 up to 7.4.191112 (SP1) are
+supported. The installation steps described within this document assume that
+you're not using the bundled Python instance and have instead installed a
+Python 2.x interpreter separately.
 
 ----------------------------
 Installing the actual plugin


### PR DESCRIPTION
This simply updates the supported versions of IDA as specified in the documentation. As of now with PR #48, we support versions of IDA from 6.8 up to the most recent 7.4.191112 (SP1).

This closes issue #44.