### PR TITLE
Deprecated the noapi hooks in favor of an implementation that prevent recursion issues

### DIFF
--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -147,10 +147,10 @@ class address(commentbase):
     @classmethod
     def changing(cls, ea, repeatable_cmt, newcmt):
         if not cls.is_ready():
-            return logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Ignoring comment.changing event (database not ready) for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
+            return logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Ignoring comment.changing event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
 
         # Grab our old comment, because we're going to submit this later to a coro
-        logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Received comment.changing event for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
+        logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Received comment.changing event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
         oldcmt = utils.string.of(idaapi.get_cmt(ea, repeatable_cmt))
 
         # First disable our hooks so that we can prevent re-entrancy issues
@@ -178,10 +178,10 @@ class address(commentbase):
     @classmethod
     def changed(cls, ea, repeatable_cmt):
         if not cls.is_ready():
-            return logging.debug(u"{:s}.changed({:#x}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
+            return logging.debug(u"{:s}.changed({:#x}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
 
         # Grab our new comment, because we're going to submit this later to our coro
-        logging.debug(u"{:s}.changed({:#x}, {:d}) : Received comment.changed event for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
+        logging.debug(u"{:s}.changed({:#x}, {:d}) : Received comment.changed event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
         newcmt = utils.string.of(idaapi.get_cmt(ea, repeatable_cmt))
 
         # First disable our hooks so that we can prevent re-entrancy issues
@@ -332,11 +332,11 @@ class globals(commentbase):
     @classmethod
     def changing(cls, cb, a, cmt, repeatable):
         if not cls.is_ready():
-            return logging.debug(u"{:s}.changing({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changing event (database not ready) for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+            return logging.debug(u"{:s}.changing({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changing event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
 
         # First we'll check to see if this is an actual function comment by confirming
         # that we're in a function, and that our comment is not empty.
-        logging.debug(u"{:s}.changing({!s}, {:#x}, {!s}, {:d}) : Received comment.changing event for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+        logging.debug(u"{:s}.changing({!s}, {:#x}, {!s}, {:d}) : Received comment.changing event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
         fn = idaapi.get_func(interface.range.start(a))
         if fn is None and not cmt:
             return
@@ -370,11 +370,11 @@ class globals(commentbase):
     @classmethod
     def changed(cls, cb, a, cmt, repeatable):
         if not cls.is_ready():
-            return logging.debug(u"{:s}.changed({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+            return logging.debug(u"{:s}.changed({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
 
         # First we'll check to see if this is an actual function comment by confirming
         # that we're in a function, and that our comment is not empty.
-        logging.debug(u"{:s}.changed({!s}, {:#x}, {!s}, {:d}) : Received comment.changed event for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+        logging.debug(u"{:s}.changed({!s}, {:#x}, {!s}, {:d}) : Received comment.changed event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
         fn = idaapi.get_func(interface.range.start(a))
         if fn is None and not cmt:
             return
@@ -408,11 +408,11 @@ class globals(commentbase):
     @classmethod
     def old_changed(cls, cb, a, cmt, repeatable):
         if not cls.is_ready():
-            return logging.debug(u"{:s}.old_changed({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+            return logging.debug(u"{:s}.old_changed({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
 
         # first thing to do is to identify whether we're in a function or not,
         # so we first grab the address from the area_t...
-        logging.debug(u"{:s}.old_changed({!s}, {:#x}, {!s}, {:d}) : Received comment.changed event for a {:s} comment at {:x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+        logging.debug(u"{:s}.old_changed({!s}, {:#x}, {!s}, {:d}) : Received comment.changed event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
         ea = interface.range.start(a)
 
         # then we can use it to verify that we're in a function. if not, then

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -897,15 +897,6 @@ def make_ida_not_suck_cocks(nw_code):
     else:
         idaapi.__notification__.add(idaapi.NW_OPENIDB, comment.tagging.__nw_init_tagcache__, -40)
 
-    ### disable some of these hooks if they're not being legitimately called through the api
-    #if idaapi.__version__ >= 7.0:
-    #    [ ui.hook.idb.add(target, notfromapi, -1) for target in ['changing_cmt', 'cmt_changed', 'changing_range_cmt', 'range_cmt_changed'] ]
-    #elif idaapi.__version__ >= 6.9:
-    #    [ ui.hook.idb.add(target, notfromapi, -1) for target in ['changing_cmt', 'cmt_changed', 'changing_area_cmt', 'area_cmt_changed'] ]
-    #else:
-    #    ui.hook.idb.add('cmt_changed', notfromapi, -1)
-    #    ui.hook.idb.add('area_cmt_changed', notfromapi, -1)
-
     ## hook any user-entered comments so that they will also update the tagcache
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_init', address.database_init, 0)

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -345,7 +345,8 @@ class globals(commentbase):
         oldcmt = utils.string.of(idaapi.get_func_cmt(fn, repeatable))
 
         # We need to disable our hooks so that we can prevent re-entrancy issues
-        [ ui.hook.idb.disable(event) for event in ['changing_area_cmt', 'area_cmt_changed'] ]
+        hooks = ['changing_area_cmt', 'area_cmt_changed'] if idaapi.__version__ < 7.0 else ['changing_range_cmt', 'range_cmt_changed']
+        [ ui.hook.idb.disable(event) for event in hooks ]
 
         # Now we can use our coroutine to begin the comment update, so that
         # later, the "changed" event can do the actual update.
@@ -361,7 +362,7 @@ class globals(commentbase):
 
         # Last thing to do is to re-enable the hooks that we disabled
         finally:
-            [ ui.hook.idb.enable(event) for event in ['changing_area_cmt', 'area_cmt_changed'] ]
+            [ ui.hook.idb.enable(event) for event in hooks ]
 
         # And then we're ready for the "changed" event
         return
@@ -382,7 +383,8 @@ class globals(commentbase):
         newcmt = utils.string.of(idaapi.get_func_cmt(fn, repeatable))
 
         # We need to disable our hooks so that we can prevent re-entrancy issues
-        [ ui.hook.idp.disable(event) for event in ['changing_area_cmt', 'area_cmt_changed'] ]
+        hooks = ['changing_area_cmt', 'area_cmt_changed'] if idaapi.__version__ < 7.0 else ['changing_range_cmt', 'range_cmt_changed']
+        [ ui.hook.idb.disable(event) for event in hooks ]
 
         # Now we can use our coroutine to update the comment state, so that the
         # coroutine will perform the final update.
@@ -398,7 +400,7 @@ class globals(commentbase):
 
         # Last thing to do is to re-enable the hooks that we disabled
         finally:
-            [ ui.hook.idp.enable(event) for event in ['changing_area_cmt', 'area_cmt_changed'] ]
+            [ ui.hook.idb.enable(event) for event in hooks ]
 
         # We're done updating the comment, that should be it.
         return

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -684,9 +684,18 @@ def rename(ea, newname):
     return
 
 def extra_cmt_changed(ea, line_idx, cmt):
-    # FIXME: persist state for extra_cmts in order to determine
-    #        what the original value was before modification
-    # XXX: IDA doesn't seem to have an extra_cmt_changing event and instead calls this hook twice for every insertion
+    # FIXME: persist state for extra_cmts in order to determine what the original
+    #        value was before modification. IDA doesn't seem to have an
+    #        extra_cmt_changing event and instead calls this hook twice for every
+    #        insertion.
+    # XXX: this function is now busted in later versions of IDA because for some
+    #      reason, Ilfak, is now updating the extra comment prior to dispatching
+    #      this event. unfortunately, our tag cache doesn't allow us to identify
+    #      the actual number of tags that are at an address, so there's no way
+    #      to identify the actual change to the extra comment that the user made,
+    #      which totally fucks up the refcount. in the current implementation, if
+    #      we can't distinguish between the old and new extra comments, then its
+    #      simply a no-op. this is okay for now...
 
     oldcmt = internal.netnode.sup.get(ea, line_idx)
     if oldcmt is not None: oldcmt = oldcmt.rstrip('\x00')


### PR DESCRIPTION
Originally the comment-hooks that keep track of the tags the user provides was dependant on a hook called `noapi`. What this hook did was check the call-stack (by walking `sys._getframe()`) to ensure that hooks for the event would terminate ahead of time if they were coming from the `hook` module. When the `priorityhooks` were re-factored and moved entirely into the `hook` module, this broke the way that `noapi` actually worked.

The original intention of the `noapi` hook was originally used as a workaround to prevent re-entrancy issues, and as-such is a hack. The proper way to execute hooks for user-comments is to disable the hooks prior to actually updating the comments with IDA's api, and then re-enabling them afterwards.

This PR fixes the issue by re-implementing the comment hooks so that they first check if the database is ready to be tampered with. This is done by querying the state assigned by the `auto_queue_empty` hook. Once the database is ready, each hook will disable any related hooks prior to updating the database, and then re-enabling them afterwards. This way IDA won't recurse into the hook whilst the database is being updated.

This closes issue #50.