### PR TITLE
misc/hooks: fixed an invalid variable being used in the `address.old_changed` hook when logging debug logs.

### DIFF
--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -207,10 +207,10 @@ class address(commentbase):
     @classmethod
     def old_changed(cls, ea, repeatable_cmt):
         if not cls.is_ready():
-            return logging.debug(u"{:s}.old_changed({:#x}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable, 'repeatable' if repeatable else 'non-repeatable', ea))
+            return logging.debug(u"{:s}.old_changed({:#x}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
 
         # first we'll grab our comment that the user updated
-        logging.debug(u"{:s}.old_changed({:#x}, {:d}) : Received comment.changed event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable, 'repeatable' if repeatable else 'non-repeatable', ea))
+        logging.debug(u"{:s}.old_changed({:#x}, {:d}) : Received comment.changed event for a {:s} comment at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
         cmt = utils.string.of(idaapi.get_cmt(ea, repeatable_cmt))
         fn = idaapi.get_func(ea)
 


### PR DESCRIPTION
When logging debug logs via the `address.old_changed` hook, IDA passes us a boolean on whether the comment is repeatable or not as "repeatable_cmt". When logging debug logs for this, the "repeatable" variable was mistakenly being used which would result in an exception being raiseed due to a non-existent variable. This PR fixes this issue by correcting the spelling of the name so that it references the parameter that we receive from IDA.

This closes issue #59.