### PR TITLE
Fixed some compatibility issues with the usage of type libraries and declaration parsing

### DIFF
--- a/base/_declaration.py
+++ b/base/_declaration.py
@@ -77,7 +77,9 @@ def parse(info):
     # that we're responsible for raising an exception if there's a parsing
     # error of some sort. If it succeeds, then we can return our typeinfo.
     # Otherwise we return None because of the inability to parse it.
-    if idaapi.__version__ < 7.0:
+    if idaapi.__version__ < 6.9:
+        return None if idaapi.parse_decl2(til, terminated, None, ti, idaapi.PT_SIL) is None else ti
+    elif idaapi.__version__ < 7.0:
         return None if idaapi.parse_decl2(til, terminated, ti, idaapi.PT_SIL) is None else ti
     return None if idaapi.parse_decl(ti, til, terminated, idaapi.PT_SIL) is None else ti
 

--- a/base/_declaration.py
+++ b/base/_declaration.py
@@ -28,20 +28,22 @@ def arguments(ea):
 
 def size(string):
     '''Returns the size of a type described by a C declaration in `string`.'''
+    til = idaapi.cvar.idati if idaapi.__version__ < 7.0 else idaapi.get_idati()
+
     string = string.strip()
     if string.lower() == 'void':
         return 0
     elif string.startswith('class') and string.endswith('&'):
-        res = idaapi.idc_parse_decl(idaapi.cvar.idati, 'void*;', 0)
+        res = idaapi.idc_parse_decl(til, 'void*;', 0)
     else:
         semicoloned = string if string.endswith(';') else "{:s};".format(string)
-        res = idaapi.idc_parse_decl(idaapi.cvar.idati, internal.utils.string.to(semicoloned), 0)
+        res = idaapi.idc_parse_decl(til, internal.utils.string.to(semicoloned), 0)
 
     if res is None:
         raise internal.exceptions.DisassemblerError(u"Unable to parse the specified C declaration (\"{:s}\").".format(internal.utils.string.escape(string, '"')))
     _, type, _ = res
     f = idaapi.get_type_size0 if idaapi.__version__ < 6.8 else idaapi.calc_type_size
-    return f(idaapi.cvar.idati, type)
+    return f(til, type)
 
 @internal.utils.string.decorate_arguments('string')
 def demangle(string):
@@ -59,7 +61,10 @@ def mangledQ(string):
 @internal.utils.string.decorate_arguments('info')
 def parse(info):
     '''Parse the string `info` into an ``idaapi.tinfo_t``.'''
-    til, ti = idaapi.get_idati(), idaapi.tinfo_t(),
+    if idaapi.__version__ < 7.0:
+        til, ti = idaapi.cvar.idati, idaapi.tinfo_t(),
+    else:
+        til, ti = idaapi.get_idati(), idaapi.tinfo_t(),
 
     # Convert info to a string if it's a tinfo_t
     info_s = "{!s}".format(info) if isinstance(info, idaapi.tinfo_t) else info
@@ -72,6 +77,8 @@ def parse(info):
     # that we're responsible for raising an exception if there's a parsing
     # error of some sort. If it succeeds, then we can return our typeinfo.
     # Otherwise we return None because of the inability to parse it.
+    if idaapi.__version__ < 7.0:
+        return None if idaapi.parse_decl2(til, terminated, ti, idaapi.PT_SIL) is None else ti
     return None if idaapi.parse_decl(ti, til, terminated, idaapi.PT_SIL) is None else ti
 
 def string(ti):

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1566,7 +1566,7 @@ class architecture_t(object):
         # older
         if idaapi.__version__ < 7.0:
             dtype_by_size = internal.utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int)
-            dt_bitfield = idaapi.dt_bitfield
+            dt_bitfield = idaapi.dt_bitfild
         # newer
         else:
             dtype_by_size = idaapi.get_dtype_by_size
@@ -1591,7 +1591,7 @@ class architecture_t(object):
         # older
         if idaapi.__version__ < 7.0:
             dtype_by_size = internal.utils.fcompose(idaapi.get_dtyp_by_size, six.byte2int)
-            dt_bitfield = idaapi.dt_bitfield
+            dt_bitfield = idaapi.dt_bitfild
         # newer
         else:
             dtype_by_size = idaapi.get_dtype_by_size

--- a/base/function.py
+++ b/base/function.py
@@ -1804,7 +1804,8 @@ class type(object):
     @utils.multicase(info=basestring)
     def __new__(cls, func, info):
         '''Parse the typeinfo string in `info` to an ``idaapi.tinfo_t`` and apply it to the function `func`.'''
-        til = idaapi.get_idati()
+        til = idaapi.cvar.idati if idaapi.__version__ < 7.0 else idaapi.get_idati()
+
         _, ea = interface.addressOfRuntimeOrStatic(func)
         conventions = {'__cdecl', '__stdcall', '__fastcall', '__thiscall', '__pascal', '__usercall', '__userpurge'}
 
@@ -1845,7 +1846,7 @@ class type(object):
         terminated = info_s if info_s.endswith(';') else "{:s};".format(info_s)
 
         # Now we should just be able to apply it to the function.
-        ok = idaapi.apply_cdecl(idaapi.get_idati(), ea, terminated)
+        ok = idaapi.apply_cdecl(til, ea, terminated)
         if not ok:
             raise E.InvalidTypeOrValueError(u"{:s}.info({:#x}) : Unable to apply the specified type declaration (\"{!s}\").".format('.'.join((__name__, cls.__name__)), ea, utils.string.escape(info, '"')))
 

--- a/base/structure.py
+++ b/base/structure.py
@@ -1616,7 +1616,10 @@ class member_t(object):
     @utils.string.decorate_arguments('info')
     def typeinfo(self, info):
         '''Set the type info of the member to `info`.'''
-        til, ti = idaapi.get_idati(), idaapi.tinfo_t(),
+        if idaapi.__version__ < 7.0:
+            til, ti = idaapi.cvar.idati, idaapi.tinfo_t(),
+        else:
+            til, ti = idaapi.get_idati(), idaapi.tinfo_t(),
 
         # Convert info to a string if it's a tinfo_t
         info_s = "{!s}".format(info) if isinstance(info, idaapi.tinfo_t) else info
@@ -1628,7 +1631,7 @@ class member_t(object):
         # Now that we've prepped everything, ask IDA to parse this into a
         # tinfo_t for us. We pass the silent flag so that we can raise an
         # exception if there's a parsing error of some sort.
-        res = idaapi.parse_decl(ti, til, terminated, idaapi.PT_SIL)
+        res = idaapi.parse_decl2(til, terminated, ti, idaapi.PT_SIL) if idaapi.__version__ < 7.0 else idaapi.parse_decl(ti, til, terminated, idaapi.PT_SIL)
         if res is None:
             cls = self.__class__
             raise E.InvalidTypeOrValueError(u"{:s}({:#x}).typeinfo : Unable to parse the specified type declaration ({!s}).".format('.'.join((__name__, cls.__name__)), self.id, utils.string.repr(info)))

--- a/base/structure.py
+++ b/base/structure.py
@@ -1616,6 +1616,11 @@ class member_t(object):
     def typeinfo(self, info):
         '''Set the type info of the member to `info`.'''
 
+        if idaapi.__version__ < 7.0:
+            set_member_tinfo = idaapi.set_member_tinfo2
+        else:
+            set_member_tinfo = idaapi.set_member_tinfo
+
         # Parse our into parameter into a tinfo_t for us, so that we can assign it t the
         # typeinfo for the member.
         ti = internal.declaration.parse(info)
@@ -1624,7 +1629,7 @@ class member_t(object):
             raise E.InvalidTypeOrValueError(u"{:s}({:#x}).typeinfo : Unable to parse the specified type declaration ({!s}).".format('.'.join((__name__, cls.__name__)), self.id, utils.string.repr(info)))
 
         # Now we can pass our tinfo_t along with the member information to IDA.
-        res = idaapi.set_member_tinfo(self.parent.ptr, self.ptr, self.ptr.get_soff(), ti, 0)
+        res = set_member_tinfo(self.parent.ptr, self.ptr, self.ptr.get_soff(), ti, 0)
         if res == idaapi.SMT_OK:
             return
 

--- a/base/structure.py
+++ b/base/structure.py
@@ -1613,26 +1613,13 @@ class member_t(object):
         return ti
 
     @typeinfo.setter
-    @utils.string.decorate_arguments('info')
     def typeinfo(self, info):
         '''Set the type info of the member to `info`.'''
-        if idaapi.__version__ < 7.0:
-            til, ti = idaapi.cvar.idati, idaapi.tinfo_t(),
-        else:
-            til, ti = idaapi.get_idati(), idaapi.tinfo_t(),
 
-        # Convert info to a string if it's a tinfo_t
-        info_s = "{!s}".format(info) if isinstance(info, idaapi.tinfo_t) else info
-
-        # Firstly we need to ';'-terminate the type the user provided in order
-        # for IDA's parser to understand it.
-        terminated = info_s if info_s.endswith(';') else "{:s};".format(info_s)
-
-        # Now that we've prepped everything, ask IDA to parse this into a
-        # tinfo_t for us. We pass the silent flag so that we can raise an
-        # exception if there's a parsing error of some sort.
-        res = idaapi.parse_decl2(til, terminated, ti, idaapi.PT_SIL) if idaapi.__version__ < 7.0 else idaapi.parse_decl(ti, til, terminated, idaapi.PT_SIL)
-        if res is None:
+        # Parse our into parameter into a tinfo_t for us, so that we can assign it t the
+        # typeinfo for the member.
+        ti = internal.declaration.parse(info)
+        if ti is None:
             cls = self.__class__
             raise E.InvalidTypeOrValueError(u"{:s}({:#x}).typeinfo : Unable to parse the specified type declaration ({!s}).".format('.'.join((__name__, cls.__name__)), self.id, utils.string.repr(info)))
 

--- a/base/structure.py
+++ b/base/structure.py
@@ -975,7 +975,7 @@ class members_t(object):
         maxtypeinfo = max(builtins.map(utils.fcompose(operator.attrgetter('typeinfo'), "{!s}".format, operator.methodcaller('replace', ' *', '*'), len), res) or [0])
 
         for m in res:
-            six.print_(u"[{:{:d}d}] {:>{:d}x}:{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {:{:d}s} (flag={:x},dt_type={:x}{:s}){:s}".format(m.index, maxindex, m.offset, int(maxoffset), m.size, maxsize, "{!s}".format(m.typeinfo).replace(' *', '*'), int(maxtypeinfo), utils.string.repr(m.name), int(maxname), m.type, int(maxtype), m.flag, m.dt_type, '' if m.typeid is None else ",typeid={:x}".format(m.typeid), u" // {!s}".format(m.tag() if '\n' in m.comment else m.comment) if m.comment else ''))
+            six.print_(u"[{:{:d}d}] {:>{:d}x}:{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {:{:d}s} (flag={:x},dt_type={:x}{:s}){:s}".format(m.index, maxindex, m.offset, int(maxoffset), m.size, maxsize, "{!s}".format(m.typeinfo.dstr()).replace(' *', '*'), int(maxtypeinfo), utils.string.repr(m.name), int(maxname), m.type, int(maxtype), m.flag, m.dt_type, '' if m.typeid is None else ",typeid={:x}".format(m.typeid), u" // {!s}".format(m.tag() if '\n' in m.comment else m.comment) if m.comment else ''))
         return
 
     @utils.multicase()
@@ -987,8 +987,8 @@ class members_t(object):
         res = builtins.list(self.iterate(**type))
         if len(res) > 1:
             cls = self.__class__
-            map(logging.info, ((u"[{:d}] {:x}{:+#x} {:s} '{:s}' {!r}".format(m.index, m.offset, m.size, "{!s}".format(m.typeinfo).replace(' *', '*'), utils.string.escape(m.name, '\''), m.type)) for m in res))
-            logging.warn(u"{:s}({:#x}).members.by({:s}) : Found {:d} matching results. Returning the member at index {:d} offset {:x}{:+#x} with the name \"{:s}\" and typeinfo \"{:s}\".".format('.'.join((__name__, cls.__name__)), self.parent.id, searchstring, len(res), res[0].index, res[0].offset, res[0].size, utils.string.escape(res[0].fullname, '"'), utils.string.escape("{!s}".format(res[0].typeinfo).replace(' *', '*'), '"')))
+            map(logging.info, ((u"[{:d}] {:x}{:+#x} {:s} '{:s}' {!r}".format(m.index, m.offset, m.size, "{!s}".format(m.typeinfo.str()).replace(' *', '*'), utils.string.escape(m.name, '\''), m.type)) for m in res))
+            logging.warn(u"{:s}({:#x}).members.by({:s}) : Found {:d} matching results. Returning the member at index {:d} offset {:x}{:+#x} with the name \"{:s}\" and typeinfo \"{:s}\".".format('.'.join((__name__, cls.__name__)), self.parent.id, searchstring, len(res), res[0].index, res[0].offset, res[0].size, utils.string.escape(res[0].fullname, '"'), utils.string.escape("{!s}".format(res[0].typeinfo.dstr()).replace(' *', '*'), '"')))
 
         res = next(iter(res), None)
         if res is None:
@@ -1332,13 +1332,13 @@ class members_t(object):
             res.append((i, name, t, ti, ofs, size, comment or '', tag))
             mn = max(mn, len(name))
             ms = max(ms, len("{:+#x}".format(size)))
-            mti = max(mti, len("{!s}".format(ti).replace(' *', '*')))
+            mti = max(mti, len("{!s}".format(ti.dstr()).replace(' *', '*')))
 
         mi = len("{:d}".format(len(self) - 1)) if len(self) else 1
 
         if len(self):
             mo = max(map(len, map("{:x}".format, (self.baseoffset, self[-1].offset + self[-1].size))))
-            return "{!r}\n{:s}".format(self.parent, '\n'.join("[{:{:d}d}] {:>{:d}x}{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {!s} {:s}".format(i, mi, o, mo, s, ms, "{!s}".format(ti).replace(' *','*'), mti, utils.string.repr(n), mn+2, utils.string.repr(t), " // {!s}".format(utils.string.repr(T) if '\n' in c else c.encode('utf8')) if c else '') for i, n, t, ti, o, s, c, T in res))
+            return "{!r}\n{:s}".format(self.parent, '\n'.join("[{:{:d}d}] {:>{:d}x}{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {!s} {:s}".format(i, mi, o, mo, s, ms, "{!s}".format(ti.dstr()).replace(' *','*'), mti, utils.string.repr(n), mn+2, utils.string.repr(t), " // {!s}".format(utils.string.repr(T) if '\n' in c else c.encode('utf8')) if c else '') for i, n, t, ti, o, s, c, T in res))
         return "{!r}".format(self.parent)
 
 class member_t(object):
@@ -1663,7 +1663,7 @@ class member_t(object):
 
     def __repr__(self):
         '''Display the member in a readable format.'''
-        id, name, typ, comment, tag, typeinfo = self.id, self.fullname, self.type, self.comment or '', self.tag(), "{!s}".format(self.typeinfo).replace(' *', '*')
+        id, name, typ, comment, tag, typeinfo = self.id, self.fullname, self.type, self.comment or '', self.tag(), "{!s}".format(self.typeinfo.dstr()).replace(' *', '*')
         return "<member '{:s}' index={:d} offset={:-#x} size={:+#x}{:s}> {:s}".format(utils.string.escape(name, '\''), self.index, self.offset, self.size, " typeinfo='{:s}'".format(typeinfo) if len("{:s}".format(typeinfo)) else '', " // {!s}".format(utils.string.repr(tag) if '\n' in comment else comment.encode('utf8')) if comment else '')
 
     def refs(self):

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -1065,7 +1065,7 @@ class DisplayHook(object):
         elif isinstance(item, six.integer_types):
             storage.append(num_printer(item))
         elif isinstance(item, idaapi.tinfo_t):
-            storage.append("{!s}".format(item))
+            storage.append("{!s}".format(item.dstr()))
         elif item.__class__ is list:
             self.format_seq(num_printer, storage, item, '[', ']')
         elif item.__class__ is tuple:
@@ -1093,7 +1093,10 @@ class DisplayHook(object):
             return
         try:
             storage = []
-            import ida_idp
+            if idaapi.__version__ < 7.0:
+                import idaapi as ida_idp
+            else:
+                import ida_idp
             num_printer = self._print_hex
             dn = ida_idp.ph_get_flag() & ida_idp.PR_DEFNUM
             if dn == ida_idp.PRN_OCT:


### PR DESCRIPTION
Earlier versions of IDA do not support the `idaapi.get_idati()` function for determining the default type library as well as the prototype for the `idaapi.parse_decl` function which is also different.

This PR fixes these issues by replacing all instances of `idaapi.get_idati()` on earlier versions of IDA with the `idaapi.cvar.idati` property (@gool123456's solution). All instances of `idaapi.parse_decl` are also now calling the older `idaapi.parse_decl2` function with the correct prototype.

This should close the issue posed in #62.