### PR TITLE
Fixed a logic issue in the `tagging.node()` function which would mistakenly scope the netnode id with the class instead of with the database.

### DIFF
--- a/base/_comment.py
+++ b/base/_comment.py
@@ -642,8 +642,9 @@ class tagging(object):
 
     @classmethod
     def __init_tagcache__(cls, idp_modname):
-        cls.node()
-        logging.debug(u"{:s}.init_tagcache('{:s}') : Initialized tagcache with netnode \"{:s}\" and node id {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), internal.utils.string.escape(idp_modname, '\''), internal.utils.string.escape(cls.__node__, '"'), cls.__nodeid__))
+        '''Hook to create a new netnode that will contain our tag-cache.'''
+        res = cls.node(cached=False)
+        logging.debug(u"{:s}.init_tagcache('{:s}') : Initialized tag-cache with netnode \"{:s}\" and node id {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), internal.utils.string.escape(idp_modname, '\''), internal.utils.string.escape(cls.__node__, '"'), res))
 
     @classmethod
     def __nw_init_tagcache__(cls, nw_code, is_old_database):
@@ -651,13 +652,22 @@ class tagging(object):
         return cls.__init_tagcache__(idp_modname)
 
     @classmethod
-    def node(cls):
-        if hasattr(cls, '__nodeid__'):
-            return cls.__nodeid__
+    def node(cls, cached=True):
+        '''Fetch the netnode containing the tag-cache which should be named "$ tagcache".
+
+        If `cached` is changed to False, then always update the node's identifier.
+        '''
+        if cached and hasattr(cls, '__cache_id__'):
+            return cls.__cache_id__
+
+        # Explicitly try to fetch the netnode containing the tag-cache. If we were
+        # unable to find it, then create it and use that instead.
         node = internal.netnode.get(cls.__node__)
         if node == idaapi.BADADDR:
             node = internal.netnode.new(cls.__node__)
-        cls.__nodeid__ = node
+
+        # Cache the identifier for the netnode inside a class attribute
+        cls.__cache_id__ = node
         return node
 
 class contents(tagging):


### PR DESCRIPTION
This PR fixes some busted logic in the `internal.comment` module which would result in the netnode id that was allocated for the tag-cache being re-used between databases. This was because the id for the netnode was being stored within the class, and the logic for executing the `tagging.__init_tagcache__` hook was not properly ensuring that the cached identifier was being updated.

This would result in the weird symptom of there occasionally being bunk-values within the tag-cache when opening up other databases within the same instance of IDA. In all actuality, this was thrashing the values in the netnode that was cached which would've likely broken something in a database but by sheer luck hasn't done that yet. 

Rather than deleting the cached id everytime the hook is run, a new parameter was introduced to the `tagging.node()` function that would specify to use the cached version by default. If the flag in the parameter is changed, then the node id will be re-fetched or created depending on what's necessary. After introducing this new parameter to `tagging.node()`, the hook's usage of the function was modified to \_always\_ fetch (or create) the most recent id for the netnode.

This closes issue #65.