### PR TITLE
Fixed a couple of compatibility issues with hooks that are being executed in response to IDA's auto-analysis.

### DIFF
--- a/base/_comment.py
+++ b/base/_comment.py
@@ -714,7 +714,7 @@ class contents(tagging):
         try:
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
-                raise internal.exceptions.SizeMismatchError(u"{:s}._read_header({!r}, {:#x}) : The number of bytes that was decoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
+                raise internal.exceptions.SizeMismatchError(u"{:s}._read_header({!r}, {:#x}) : The number of bytes that was decoded did not match the expected size ({:#x}<>{:#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
         except Exception as E:
             logging.warn(u"{:s}._read_header({!r}, {:#x}) : An exception ({!s}) was raised while trying to decode the header for address {:#x} from sup cache associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, E, ea, key), exc_info=True)
             logging.info(u"{:s}._read_header({!r}, {:#x}) : Failure decoding the following data from sup cache: {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, encdata))
@@ -752,7 +752,7 @@ class contents(tagging):
         try:
             encdata, sz = cls.codec.encode(data)
             if sz != len(data):
-                raise internal.exceptions.SizeMismatchError(u"{:s}._write_header({!r}, {:#x}, {!s}) : The number of bytes that was encoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
+                raise internal.exceptions.SizeMismatchError(u"{:s}._write_header({!r}, {:#x}, {!s}) : The number of bytes that was encoded did not match the expected size ({:#x}<>{:#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
 
         except Exception as E:
             logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : An exception ({!s}) was raised while trying to encode the header at address {:#x} for sup cache associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), E, ea, key), exc_info=True)
@@ -760,7 +760,7 @@ class contents(tagging):
             raise internal.exceptions.SerializationError(u"{:s}._write_header({!r}, {:#x}, {!s}) : Unable to encode contents at {:#x} for sup cache associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), ea, key))
 
         if len(encdata) > internal.netnode.sup.MAX_SIZE:
-            logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : Reached tag limit size ({:+#x} > {:+#x}) in function with key {:#x}. Possible tag-cache corruption encountered.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), len(encdata), internal.netnode.sup.MAX_SIZE, key))
+            logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : Reached tag limit size ({:#x}>{:#x}) in function with key {:#x}. Possible tag-cache corruption encountered.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), len(encdata), internal.netnode.sup.MAX_SIZE, key))
 
         ok = internal.netnode.sup.set(node, key, encdata)
         return bool(ok)
@@ -782,7 +782,7 @@ class contents(tagging):
         try:
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
-                raise internal.exceptions.SizeMismatchError(u"{:s}._read({!r}, {:#x}) : The number of bytes that was decoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
+                raise internal.exceptions.SizeMismatchError(u"{:s}._read({!r}, {:#x}) : The number of bytes that was decoded did not match the expected size ({:#x}<>{:#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
 
         except Exception as E:
             logging.warn(u"{:s}._read({!r}, {:#x}) : An exception ({!s}) was raised while trying to decode contents for address {:#x} from blob ({!s}) associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, E, ea, cls.btag, key), exc_info=True)
@@ -838,7 +838,7 @@ class contents(tagging):
             raise internal.exceptions.SerializationError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to encode contents at address {:#x} for blob ({!s}) associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), ea, cls.btag, key))
 
         if sz != len(data):
-            raise internal.exceptions.SizeMismatchError(u"{:s}._write({!r}, {:#x}, {!s}) : The number of bytes that was encoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
+            raise internal.exceptions.SizeMismatchError(u"{:s}._write({!r}, {:#x}, {!s}) : The number of bytes that was encoded did not match the expected size ({:#x}<>{:#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
 
         # write blob
         ok = internal.netnode.blob.set(key, cls.btag, encdata)
@@ -861,7 +861,7 @@ class contents(tagging):
             encdata = internal.netnode.sup.get(node, ea)
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
-                logging.warn(u"{:s}.iterate() : Failed decoding tag names out of sup cache for {:#x} due to the length of encoded data ({:+#x}) not matching the expected size ({:#x}).".format('.'.join(('internal', __name__, cls.__name__)), ea, len(encdata), sz))
+                logging.warn(u"{:s}.iterate() : Failed decoding tag names out of sup cache for address {:#x} due to the length of encoded data not matching the expected size ({:#x}<>{:#x}).".format('.'.join(('internal', __name__, cls.__name__)), ea, len(encdata), sz))
             res = cls.marshaller.loads(data)
             yield ea, res
         return

--- a/base/_comment.py
+++ b/base/_comment.py
@@ -714,15 +714,15 @@ class contents(tagging):
         try:
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
-                raise internal.exceptions.SizeMismatchError(u"{:s}._read_header({!r}, {:#x}) : The number of bytes that was decoded ({:#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
+                raise internal.exceptions.SizeMismatchError(u"{:s}._read_header({!r}, {:#x}) : The number of bytes that was decoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
         except Exception as E:
-            logging.warn(u"{:s}._read_header({!r}, {:#x}) : An exception ({!s}) was raised while trying to decode contents for {:#x} at {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, E, key, ea), exc_info=True)
-            raise internal.exceptions.SerializationError(u"{:s}._read_header({!r}, {:#x}) : Unable to decode contents for {:#x} at {:#x}. The data that failed to be decoded is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, key, ea, encdata))
+            logging.warn(u"{:s}._read_header({!r}, {:#x}) : An exception ({!s}) was raised while trying to decode contents from sup cache at {:#x} associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, E, ea, key), exc_info=True)
+            raise internal.exceptions.SerializationError(u"{:s}._read_header({!r}, {:#x}) : Unable to decode contents from sup cache at {:#x} associated with key {:#x}. The data that failed to be decoded is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, ea, key, encdata))
 
         try:
             result = cls.marshaller.loads(data)
         except Exception as E:
-            raise internal.exceptions.SerializationError(u"{:s}._read_header({!r}, {:#x}) : Unable to unmarshal contents for {:#x} at {:#x}. The data that failed to be unmarshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, key, ea, data))
+            raise internal.exceptions.SerializationError(u"{:s}._read_header({!r}, {:#x}) : Unable to unmarshal contents from sup cache at {:#x} associated with key {:#x}. The data that failed to be unmarshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, ea, key, data))
         return result
 
     @classmethod
@@ -744,19 +744,19 @@ class contents(tagging):
             data = cls.marshaller.dumps(value)
 
         except Exception as E:
-            raise internal.exceptions.SerializationError(u"{:s}._write_header({!r}, {:#x}, {!s}) : Unable to marshal contents for {:#x} at {:#x}. The data that failed to be marshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key, ea, value))
+            raise internal.exceptions.SerializationError(u"{:s}._write_header({!r}, {:#x}, {!s}) : Unable to marshal contents for sup cache at {:#x} associated with key {:#x}. The data that failed to be marshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), ea, key, value))
 
         try:
             encdata, sz = cls.codec.encode(data)
             if sz != len(data):
-                raise internal.exceptions.SizeMismatchError(u"{:s}._write_header({!r}, {:#x}, {!s}) : The number of bytes that was encoded ({:#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
+                raise internal.exceptions.SizeMismatchError(u"{:s}._write_header({!r}, {:#x}, {!s}) : The number of bytes that was encoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
 
         except Exception as E:
-            logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : An exception ({!s}) was raised while trying to encode contents for {:#x} at {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), E, key, ea), exc_info=True)
-            raise internal.exceptions.SerializationError(u"{:s}._write_header({!r}, {:#x}, {!s}) : Unable to encode contents for {:#x} at {:#x}. The data that failed to be encoded is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key, ea, data))
+            logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : An exception ({!s}) was raised while trying to encode contents for sup cache at {:#x} associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), E, ea, key), exc_info=True)
+            raise internal.exceptions.SerializationError(u"{:s}._write_header({!r}, {:#x}, {!s}) : Unable to encode contents for sup cache at {:#x} associated with key {:#x}. The data that failed to be encoded is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), ea, key, data))
 
         if len(encdata) > internal.netnode.sup.MAX_SIZE:
-            logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : Too many tags within function. The size {:#x} must be < {:#x}. Ignoring it.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), len(encdata), internal.netnode.sup.MAX_SIZE))
+            logging.warn(u"{:s}._write_header({!r}, {:#x}, {!s}) : Reached tag limit size within function ({:+#x} > {:+#x})...possible tag-cache corruption.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), len(encdata), internal.netnode.sup.MAX_SIZE))
 
         ok = internal.netnode.sup.set(node, key, encdata)
         return bool(ok)
@@ -778,17 +778,17 @@ class contents(tagging):
         try:
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
-                raise internal.exceptions.SizeMismatchError(u"{:s}._read({!r}, {:#x}) : The number of bytes that was decoded ({:#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
+                raise internal.exceptions.SizeMismatchError(u"{:s}._read({!r}, {:#x}) : The number of bytes that was decoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, sz, len(encdata)))
 
         except Exception as E:
-            logging.warn(u"{:s}._read({!r}, {:#x}) : An exception ({!s}) was raised while trying to decode contents for {:#x} at {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, E, key, ea), exc_info=True)
-            raise internal.exceptions.SerializationError(u"{:s}._read({!r}, {:#x}) : Unable to decode contents for {:#x} at {:#x}. The data that failed to decode is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, key, ea, encdata))
+            logging.warn(u"{:s}._read({!r}, {:#x}) : An exception ({!s}) was raised while trying to decode contents from blob ({!s}) at {:#x} associated with key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, E, cls.btag, ea, key), exc_info=True)
+            raise internal.exceptions.SerializationError(u"{:s}._read({!r}, {:#x}) : Unable to decode contents from blob ({!s}) at {:#x} associated with key {:#x}. The data that failed to decode is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, cls.btag, ea, key, encdata))
 
         try:
             result = cls.marshaller.loads(data)
 
         except Exception as E:
-            raise internal.exceptions.SerializationError(u"{:s}._read({!r}, {:#x}) : Unable to unmarshal contents for {:#x} at {:#x}. The data that failed to be unmarshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, key, ea, data))
+            raise internal.exceptions.SerializationError(u"{:s}._read({!r}, {:#x}) : Unable to unmarshal contents from blob ({!s}) at {:#x} associated with key {:#x}. The data that failed to be unmarshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, cls.btag, ea, key, data))
         return result
 
     @classmethod
@@ -807,12 +807,11 @@ class contents(tagging):
             try:
                 ok = cls._write_header(target, ea, None)
                 if not ok:
-                    logging.debug(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to remove address from sup cache with the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key))
+                    logging.debug(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to remove address {:#x} from sup cache associated with the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), ea, key))
 
             finally:
                 count = internal.netnode.blob.remove(key, cls.btag)
-                if not count:
-                    logging.debug(u"{:s}._write({!r}, {:#x}, {!s}) : Ignoring failed removal of non-existent blob ({!s}) for the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), cls.btag, key))
+                logging.debug(u"{:s}._write({!r}, {:#x}, {!s}) : Removed {:d} blob{:s} ({!s}) associated with the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), count, '' if count == 1 else 's', cls.btag, key))
 
             return True
 
@@ -822,27 +821,27 @@ class contents(tagging):
             data = cls.marshaller.dumps(res)
 
         except Exception as E:
-            raise internal.exceptions.SerializationError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to marshal contents for {:#x} at {:#x}. The data that failed to be marshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key, ea, res))
+            raise internal.exceptions.SerializationError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to marshal contents for blob ({!s}) at {:#x} associated with key {:#x}. The data that failed to be marshalled is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), cls.btag, ea, key, res))
 
         try:
             encdata, sz = cls.codec.encode(data)
 
         except Exception as E:
-            raise internal.exceptions.SerializationError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to encode contents for {:#x} at {:#x}. The data that failed to be encoded is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key, ea, data))
+            raise internal.exceptions.SerializationError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to encode contents for blob ({!s}) at {:#x} associated with key {:#x}. The data that failed to be encoded is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), cls.btag, ea, key, data))
 
         if sz != len(data):
-            raise internal.exceptions.SizeMismatchError(u"{:s}._write({!r}, {:#x}, {!s}) : The number of bytes that was encoded ({:#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
+            raise internal.exceptions.SizeMismatchError(u"{:s}._write({!r}, {:#x}, {!s}) : The number of bytes that was encoded ({:+#x}) did not match the expected size ({:+#x}).".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), sz, len(data)))
 
         # write blob
         ok = internal.netnode.blob.set(key, cls.btag, encdata)
         if not ok:
-            raise internal.exceptions.DisassemblerError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to set contents for {:#x} at {:#x}. The data that failed to be set is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key, ea, encdata))
+            raise internal.exceptions.DisassemblerError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to set contents for blob ({!s}) at {:#x} associated with the key {:#x}. The data that failed to be set is {!r}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), cls.btag, ea, key, encdata))
 
         # update sup cache with keys
         res = set(six.viewkeys(value))
         ok = cls._write_header(target, ea, res)
         if not ok:
-            raise internal.exceptions.DisassemblerError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to set address to sup cache with the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key))
+            raise internal.exceptions.DisassemblerError(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to set address on sup cache associated with the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key))
         return ok
 
     @classmethod
@@ -853,7 +852,7 @@ class contents(tagging):
             encdata = internal.netnode.sup.get(node, ea)
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
-                logging.warn(u"{:s}.iterate() : Failed decoding tag names out of sup cache for {:#x} due to the length of encoded data ({:#x}) not matching the expected size ({:#x}).".format('.'.join(('internal', __name__, cls.__name__)), ea, len(encdata), sz))
+                logging.warn(u"{:s}.iterate() : Failed decoding tag names out of sup cache for {:#x} due to the length of encoded data ({:+#x}) not matching the expected size ({:#x}).".format('.'.join(('internal', __name__, cls.__name__)), ea, len(encdata), sz))
             res = cls.marshaller.loads(data)
             yield ea, res
         return

--- a/base/_comment.py
+++ b/base/_comment.py
@@ -740,8 +740,7 @@ class contents(tagging):
 
         # If our header is empty, then we just need to remove the supvalue
         if not value:
-            ok = internal.netnode.sup.remove(node, key)
-            return bool(ok)
+            return bool(internal.netnode.sup.remove(node, key))
 
         try:
             data = cls.marshaller.dumps(value)

--- a/base/_comment.py
+++ b/base/_comment.py
@@ -808,8 +808,13 @@ class contents(tagging):
                 ok = cls._write_header(target, ea, None)
                 if not ok:
                     logging.debug(u"{:s}._write({!r}, {:#x}, {!s}) : Unable to remove address from sup cache with the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), key))
+
             finally:
-                return internal.netnode.blob.remove(key, cls.btag)
+                count = internal.netnode.blob.remove(key, cls.btag)
+                if not count:
+                    logging.debug(u"{:s}._write({!r}, {:#x}, {!s}) : Ignoring failed removal of non-existent blob ({!s}) for the key {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), target, ea, internal.utils.string.repr(value), cls.btag, key))
+
+            return True
 
         # update blob for given address
         res = value

--- a/base/_comment.py
+++ b/base/_comment.py
@@ -862,7 +862,8 @@ class contents(tagging):
 
         If `target` is undefined or ``None`` then use `address` to locate the function.
         """
-        res = cls._read(target.get('target', None), address) or {}
+        key = target.get('target', None)
+        res = cls._read(key, address) or {}
         state, cache = res.get(cls.__tags__, {}), res.get(cls.__address__, {})
 
         state[name] = refs = state.get(name, 0) + 1
@@ -874,7 +875,7 @@ class contents(tagging):
         if cache: res[cls.__address__] = cache
         else: del res[cls.__address__]
 
-        cls._write(target.get('target', None), address, res)
+        cls._write(key, address, res)
         return refs
 
     @classmethod
@@ -883,7 +884,8 @@ class contents(tagging):
 
         If `target` is undefined or ``None`` then use `address` to locate the function.
         """
-        res = cls._read(target.get('target', None), address) or {}
+        key = target.get('target', None)
+        res = cls._read(key, address) or {}
         state, cache = res.get(cls.__tags__, {}), res.get(cls.__address__, {})
 
         refs, count = state.pop(name, 0) - 1, cache.pop(address, 0) - 1
@@ -899,7 +901,7 @@ class contents(tagging):
         if cache: res[cls.__address__] = cache
         else: res.pop(cls.__address__, None)
 
-        cls._write(target.get('target', None), address, res)
+        cls._write(key, address, res)
         return refs
 
     @classmethod
@@ -908,7 +910,8 @@ class contents(tagging):
 
         If `target` is undefined or ``None`` then use `address` to locate the function.
         """
-        res = cls._read(target.get('target', None), address) or {}
+        key = target.get('target', None)
+        res = cls._read(key, address) or {}
         res = res.get(cls.__tags__, {})
         return set(six.viewkeys(res))
 
@@ -918,7 +921,8 @@ class contents(tagging):
 
         If `target` is undefined or ``None`` then use `address` to locate the function.
         """
-        res = cls._read(target.get('target', None), address) or {}
+        key = target.get('target', None)
+        res = cls._read(key, address) or {}
         res = res.get(cls.__address__, {})
         return sorted(six.viewkeys(res))
 
@@ -928,7 +932,8 @@ class contents(tagging):
 
         If `target` is undefined or ``None`` then use `address` to locate the function.
         """
-        state = cls._read(target.get('target', None), address) or {}
+        key = target.get('target', None)
+        state = cls._read(key, address) or {}
 
         res = state.get(cls.__tags__, {})
         if count > 0:
@@ -941,7 +946,7 @@ class contents(tagging):
         else:
             state.pop(cls.__tags__, None)
 
-        ok = cls._write(target.get('target', None), address, state)
+        ok = cls._write(key, address, state)
         if ok:
             return state
         raise internal.exceptions.ReadOrWriteError(u"{:s}.set_name({:#x}, {!r}, {:d}{:s}) : Unable to write name to address {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), address, name, count, ', {:s}'.format(internal.utils.string.kwargs(target)) if target else '', address))
@@ -952,7 +957,8 @@ class contents(tagging):
 
         If `target` is undefined or ``None`` then use `address` to locate the function.
         """
-        state = cls._read(target.get('target', None), address) or {}
+        key = target.get('target', None)
+        state = cls._read(key, address) or {}
 
         res = state.get(cls.__address__, {})
         if count > 0:
@@ -965,7 +971,7 @@ class contents(tagging):
         else:
             state.pop(cls.__address__, None)
 
-        ok = cls._write(target.get('target', None), address, state)
+        ok = cls._write(key, address, state)
         if ok:
             return state
         raise internal.exceptions.ReadOrWriteError(u"{:s}.set_address({:#x}, {:d}{:s}) : Unable to write name to address {:#x}.".format('.'.join(('internal', __name__, cls.__name__)), address, count, ', {:s}'.format(internal.utils.string.kwargs(target)) if target else '', address))

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -779,10 +779,10 @@ def func_tail_removed(pfn, ea):
     if State != state.ready: return
 
     # first we'll grab the addresses from our refs
-    res = internal.comment.contents.address(ea, target=interface.range.start(pfn))
+    listable = internal.comment.contents.address(ea, target=interface.range.start(pfn))
 
     # these are sorted, so first we'll filter out what doesn't belong
-    missing = [ item for item in res if idaapi.get_func(item) != pfn ]
+    missing = [ item for item in listable if not idaapi.get_func(item) or idaapi.get_func(item) != pfn ]
 
     # if there was nothing found, then we can simply exit the hook early
     if not missing:

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -781,7 +781,12 @@ def func_tail_removed(pfn, ea):
     # first we'll grab the addresses from our refs
     listable = internal.comment.contents.address(ea, target=interface.range.start(pfn))
 
-    # these are sorted, so first we'll filter out what doesn't belong
+    # these should already be sorted, so our first step is to filter out what
+    # doesn't belong. in order to work around one of the issues posed in the
+    # issue arizvisa/ida-minsc#61, we need to explicitly check that each item is
+    # not None prior to their comparison against `pfn`. this is needed in order
+    # to work around a null-pointer exception raised by SWIG when it calls the
+    # area_t.__ne__ method to do the comparison.
     missing = [ item for item in listable if not idaapi.get_func(item) or idaapi.get_func(item) != pfn ]
 
     # if there was nothing found, then we can simply exit the hook early

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -784,6 +784,10 @@ def func_tail_removed(pfn, ea):
     # these are sorted, so first we'll filter out what doesn't belong
     missing = [ item for item in res if idaapi.get_func(item) != pfn ]
 
+    # if there was nothing found, then we can simply exit the hook early
+    if not missing:
+        return
+
     # now iterate through the min/max of the list as hopefully this is
     # our event.
     for ea in database.address.iterate(min(missing), max(missing)):


### PR DESCRIPTION
When IDA runs its auto-analysis, a number of hooks are executed in order to ensure that the tag-cache is updated in response to IDA's changes. When executing these hooks (specifically when earlier versions of IDA apply a type library to the database), a handful of unhandled exceptions are raised which are pretty alarming. The hooks that were causing these issues were the `idb.func_tail_removed`, and the `idb.cmt_changed` hooks.

Specifically there were 3 types of exceptions that were being raised by both of these two hooks.
- ReadOrWriteError -- which claimed that it was unable to write to the cache at a given address
- ValueError -- which was because the `min()` and `max()` keywords were being used on an empty list
- Some kind of null pointer exception from swig -- which was because of a comparison of an `idaapi.area_t` to `None`.

After cleaning up some of the exception handling and adding logs to `internal.comment`, it was discovered that the first `ReadOrWriteError` was happening because an empty value was being passed to the `contents._write` function, and the result of an API call was being blindly returned. This resulted in the function trying to remove a netnode from the given address, and since there wasn't anything at that address, the value `0` was returned. As this value is an implicit false, a sanity check was raising an exception thinking some kind of critical error was happening which was not the case.

The second `ValueError` exception was being raised within the `idb.func_tail_removed` hook. This issue was happening because the implementation of the hook was filtering out addresses that were outside of the function in order to determine where to move any tags that are found. If the filter ended up not finding any addresses, the resulting list would be empty. Both the `min()` and `max()` keywords raise an exception on an empty list, which is where this one came from.

The last exception was very strange in that the `idb.func_tail_removed` hook was performing the aforementioned filter to determine what addresses were within a function versus being outside a function. This filter is being done with the `idaapi.get_func(ea)` api which should return `None` when the given address is not within a function. For some strange reason, comparing an `idaapi.area_t` with `None` will result in a null-pointer exception being raised by swig from the `area_t.__ne__` method on earlier versions of IDA. This doesn't happen in all cases, and I couldn't reproduce it with just any old `idaapi.area_t` or `idaapi.func_t`. It seems that when being called from the `idb.func_tail_removed` hook, its `pfn` parameter is in some weird state where when it is compared to `None`, its SWIG wrapper tries to dereference it.

The first exception was fixed by simply treating the count that was being returned as a non-critical issue. The second exception was fixed by checking if the list was filtered to empty, and then terminating instead of attempting to process it. The last exception from SWIG was fixed by explicitly checking if the address is going to be `None` prior to comparing it against the `pfn` parameter. This way we can avoid comparing it against `None` and excluding the item before letting SWIG do its comparison.

This should hopefully close issue #61.