### PR TITLE
Modified the support for tags so that they can be encoded in both repeatable and non-repeatable comments.

### DIFF
--- a/base/_interface.py
+++ b/base/_interface.py
@@ -286,6 +286,10 @@ class prioritybase(object):
             continue
         return not notok
 
+    @property
+    def available(self):
+        return {item for item in self.__cache__}
+
     def enable(self, target):
         '''Enable any callables for the specified `target` that has been previously disabled.'''
         if target not in self.__disabled:

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -288,6 +288,7 @@ class prioritybase(object):
 
     @property
     def available(self):
+        '''Return all of the available targets that can be either enabled or disabled.'''
         return {item for item in self.__cache__}
 
     def enable(self, target):

--- a/base/database.py
+++ b/base/database.py
@@ -1557,7 +1557,7 @@ def tag(ea, key, value):
     ea = interface.address.inside(ea)
     state_correct = internal.comment.decode(comment(ea, repeatable=repeatable))
     state_wrong = internal.comment.decode(comment(ea, repeatable=not repeatable))
-    state_runtime = internal.comment.decode(function.comment(ea, repeatable=True))
+    state_runtime = internal.comment.decode(function.comment(ea, repeatable=True)) if func else {}
     if rt:
         rt, state, where = (True, state_runtime, True) if key in state_runtime else (False, state_wrong, False) if key in state_wrong else (True, state_runtime, True)
     else:
@@ -1626,7 +1626,7 @@ def tag(ea, key, none):
     # then it doesn't really matter since we're going to raise an exception anyways.
     state_correct = internal.comment.decode(comment(ea, repeatable=repeatable))
     state_wrong = internal.comment.decode(comment(ea, repeatable=not repeatable))
-    state_runtime = internal.comment.decode(function.comment(ea, repeatable=True))
+    state_runtime = internal.comment.decode(function.comment(ea, repeatable=True)) if func else {}
     if rt:
         rt, state, where = (True, state_runtime, True) if key in state_runtime else (False, state_wrong, False) if key in state_wrong else (True, state_runtime, True)
     else:

--- a/base/database.py
+++ b/base/database.py
@@ -1539,9 +1539,7 @@ def tag(ea, key, value):
 
     # grab the current tag out of the correct repeatable or non-repeatable comment
     ea = interface.address.inside(ea)
-    state = internal.comment.decode(comment(ea, repeatable=not repeatable))
-    state and comment(ea, '', repeatable=not repeatable) # clear the old one
-    state.update(internal.comment.decode(comment(ea, repeatable=repeatable)))
+    state = internal.comment.decode(comment(ea, repeatable=repeatable))
 
     # update the tag's reference if we're actually adding a key and not overwriting it
     if key not in state:
@@ -1582,9 +1580,7 @@ def tag(ea, key, none):
     repeatable = False if func and function.within(ea) else True
 
     # fetch the dict, remove the key, then write it back.
-    state = internal.comment.decode(comment(ea, repeatable=not repeatable))
-    state and comment(ea, '', repeatable=not repeatable) # clear the old one
-    state.update(internal.comment.decode(comment(ea, repeatable=repeatable)))
+    state = internal.comment.decode(comment(ea, repeatable=repeatable))
     if key not in state:
         raise E.MissingTagError(u"{:s}.tag({:#x}, {!r}, {!s}) : Unable to remove tag \"{:s}\" from address.".format(__name__, ea, key, none, utils.string.escape(key, '"')))
     res = state.pop(key)

--- a/base/function.py
+++ b/base/function.py
@@ -1641,11 +1641,11 @@ def tag(func, key, value):
         return type(fn, value)
 
     # decode both comments and figure out which type of comment the tag is
-    # currently in. if it's in  neither then we just fall back to a repeatable
-    # comment because it's a function.
-    state_correct = internal.comment.decode(comment(fn, repeatable=True))
-    state_wrong = internal.comment.decode(comment(fn, repeatable=False))
-    state, where = (state_correct, True) if key in state_correct else (state_wrong, False) if key in state_wrong else (state_correct, True)
+    # currently in. if it's in neither then we just fall back to a repeatable
+    # comment because we're a function.
+    state_correct = internal.comment.decode(comment(fn, repeatable=True)), True
+    state_wrong = internal.comment.decode(comment(fn, repeatable=False)), False
+    state, where = state_correct if key in state_correct[0] else state_wrong if key in state_wrong[0] else state_correct
 
     # grab the previous value, and update the state with the new one
     res, state[key] = state.get(key, None), value
@@ -1704,12 +1704,12 @@ def tag(func, key, none):
     # decode both comment types so we can figure out which one the user's
     # key is in. if we don't find it in either then it doesn't matter since
     # we're gonna raise an exception anyways.
-    state_correct = internal.comment.decode(comment(fn, repeatable=True))
-    state_wrong = internal.comment.decode(comment(fn, repeatable=False))
-    state, where = (state_correct, repeatable) if key in state_correct else (state_wrong, not repeatable) if key in state_wrong else (state_correct, repeatable)
+    state_correct = internal.comment.decode(comment(fn, repeatable=True)), True
+    state_wrong = internal.comment.decode(comment(fn, repeatable=False)), False
+    state, where = state_correct if key in state_correct[0] else state_wrong if key in state_wrong[0] else state_correct
 
     if key not in state:
-        raise E.MissingFunctionTagError(u"{:s}.tag({:#x}, {!r}, {!s}) : Unable to remove tag \"{:s}\" from function.".format(__name__, interface.range.start(fn), key, none, utils.string.escape(key, '"')))
+        raise E.MissingFunctionTagError(u"{:s}.tag({:#x}, {!r}, {!s}) : Unable to remove non-existent tag \"{:s}\" from function.".format(__name__, interface.range.start(fn), key, none, utils.string.escape(key, '"')))
     res = state.pop(key)
 
     # guard the modification of the comment so that we don't tamper with any references

--- a/base/function.py
+++ b/base/function.py
@@ -1640,8 +1640,14 @@ def tag(func, key, value):
     if key == '__typeinfo__':
         return type(fn, value)
 
-    # decode the comment, fetch the old key, re-assign the new key, and then re-encode it
-    state = internal.comment.decode(comment(fn, repeatable=True))
+    # decode both comments and figure out which type of comment the tag is
+    # currently in. if it's in  neither then we just fall back to a repeatable
+    # comment because it's a function.
+    state_correct = internal.comment.decode(comment(fn, repeatable=True))
+    state_wrong = internal.comment.decode(comment(fn, repeatable=False))
+    state, where = (state_correct, True) if key in state_correct else (state_wrong, False) if key in state_wrong else (state_correct, True)
+
+    # grab the previous value, and update the state with the new one
     res, state[key] = state.get(key, None), value
 
     # guard the modification of the comment so we don't tamper with any references
@@ -1651,7 +1657,7 @@ def tag(func, key, value):
     except Exception:
         raise
     else:
-        comment(fn, internal.comment.encode(state), repeatable=True)
+        comment(fn, internal.comment.encode(state), repeatable=where)
     finally:
         [ ui.hook.idb.enable(item) for item in hooks ]
 
@@ -1695,8 +1701,13 @@ def tag(func, key, none):
     elif key == '__typeinfo__':
         return type(fn, None)
 
-    # decode the comment, remove the key, and then re-encode it
-    state = internal.comment.decode(comment(fn, repeatable=True))
+    # decode both comment types so we can figure out which one the user's
+    # key is in. if we don't find it in either then it doesn't matter since
+    # we're gonna raise an exception anyways.
+    state_correct = internal.comment.decode(comment(fn, repeatable=True))
+    state_wrong = internal.comment.decode(comment(fn, repeatable=False))
+    state, where = (state_correct, repeatable) if key in state_correct else (state_wrong, not repeatable) if key in state_wrong else (state_correct, repeatable)
+
     if key not in state:
         raise E.MissingFunctionTagError(u"{:s}.tag({:#x}, {!r}, {!s}) : Unable to remove tag \"{:s}\" from function.".format(__name__, interface.range.start(fn), key, none, utils.string.escape(key, '"')))
     res = state.pop(key)
@@ -1708,11 +1719,12 @@ def tag(func, key, none):
     except Exception:
         raise
     else:
-        comment(fn, internal.comment.encode(state), repeatable=True)
+        comment(fn, internal.comment.encode(state), repeatable=where)
     finally:
         [ ui.hook.idb.enable(item) for item in hooks ]
 
-    # if we got here without raising an exception, then the tag was stored so update the cache
+    # if we got here without raising an exception, then the tag was remove and
+    # we just need to update the cache with its removal.
     internal.comment.globals.dec(interface.range.start(fn), key)
     return res
 

--- a/custom/tagfix.py
+++ b/custom/tagfix.py
@@ -53,39 +53,6 @@ def fetch_contents(fn):
         continue
     return func.address(fn), addr, tags
 
-def check_contents(ea):
-    '''Validate the cache defined for the contents of the function `ea`.'''
-    node, key = internal.netnode.get(internal.comment.tagging.node()), internal.comment.contents._key(ea)
-    tag = internal.comment.decode(db.comment(key))
-
-    encdata = internal.netnode.sup.get(node, key)
-    if encdata is None and tag: return False
-    if not isinstance(tag, dict): return False
-    if not tag: return True
-    if '__address__' not in tag: return False
-    if '__tags__' not in tag: return False
-    return True
-
-def check_global(ea):
-    '''Validate the cache defined for the global at the address `ea`.'''
-    if func.within(ea): return False
-
-    cache = internal.comment.decode(db.comment(db.top()))
-    cache.update( internal.comment.decode(db.comment(db.bottom())) )
-
-    node = internal.netnode.get(internal.comment.tagging.node())
-    tag = internal.comment.decode(db.comment(ea))
-
-    if cache and '__address__' not in cache: return False
-    if not cache and tag: return False
-    count = internal.netnode.alt.get(node, ea)
-    if tag and not count: return False
-
-    if len(tag['__address__']) != count: return False
-    keys = tag['__tags__']
-    if any(t not in cache for t in keys): return False
-    return True
-
 def fetch_globals_functions():
     """Fetch the reference count for the global tags (function) in the database.
 

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -60,13 +60,14 @@ class address(commentbase):
     @classmethod
     def _update_refs(cls, ea, old, new):
         f = idaapi.get_func(ea)
+        logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
         for key in old.viewkeys() ^ new.viewkeys():
             if key not in new:
-                logging.debug(u"{:s}.update_refs({:#x}) : Decreasing refcount for {!s} at {:s}. Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
+                logging.debug(u"{:s}.update_refs({:#x}) : Decreasing refcount for {!s} at {:s}.".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', ea))
                 if f: internal.comment.contents.dec(ea, key)
                 else: internal.comment.globals.dec(ea, key)
             if key not in old:
-                logging.debug(u"{:s}.update_refs({:#x}) : Increasing refcount for {!s} at {:s}. Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
+                logging.debug(u"{:s}.update_refs({:#x}) : Increasing refcount for {!s} at {:s}.".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', ea))
                 if f: internal.comment.contents.inc(ea, key)
                 else: internal.comment.globals.inc(ea, key)
             continue
@@ -75,8 +76,9 @@ class address(commentbase):
     @classmethod
     def _create_refs(cls, ea, res):
         f = idaapi.get_func(ea)
+        logging.debug(u"{:s}.create_refs({:#x}) : Creating keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(res.viewkeys())))
         for key in res.viewkeys():
-            logging.debug(u"{:s}.create_refs({:#x}) : Increasing refcount for {!s} at {:s} for keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', utils.string.repr(res.viewkeys())))
+            logging.debug(u"{:s}.create_refs({:#x}) : Increasing refcount for {!s} at {:s} {:#x}.".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', ea))
             if f: internal.comment.contents.inc(ea, key)
             else: internal.comment.globals.inc(ea, key)
         return
@@ -84,8 +86,9 @@ class address(commentbase):
     @classmethod
     def _delete_refs(cls, ea, res):
         f = idaapi.get_func(ea)
+        logging.debug(u"{:s}.delete_refs({:#x}) : Deleting keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(res.viewkeys())))
         for key in res.viewkeys():
-            logging.debug(u"{:s}.delete_refs({:#x}) : Decreasing refcount for {!s} at {:s} for keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea,  utils.string.repr(key), 'address', utils.string.repr(res.viewkeys())))
+            logging.debug(u"{:s}.delete_refs({:#x}) : Decreasing refcount for {!s} at {:s} {:#x}.".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(key), 'address', ea))
             if f: internal.comment.contents.dec(ea, key)
             else: internal.comment.globals.dec(ea, key)
         return
@@ -247,28 +250,31 @@ class address(commentbase):
 class globals(commentbase):
     @classmethod
     def _update_refs(cls, fn, old, new):
+        logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
         for key in old.viewkeys() ^ new.viewkeys():
             if key not in new:
-                logging.debug(u"{:s}.update_refs({:#x}) : Decreasing refcount for {!s} at {:s}. Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
+                logging.debug(u"{:s}.update_refs({:#x}) : Decreasing refcount for {!s} at {:s} {:#x}.".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
                 internal.comment.globals.dec(interface.range.start(fn), key)
             if key not in old:
-                logging.debug(u"{:s}.update_refs({:#x}) : Increasing refcount for {!s} at {:s}. Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
+                logging.debug(u"{:s}.update_refs({:#x}) : Increasing refcount for {!s} at {:s} {:#x}.".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
                 internal.comment.globals.inc(interface.range.start(fn), key)
             continue
         return
 
     @classmethod
     def _create_refs(cls, fn, res):
+        logging.debug(u"{:s}.create_refs({:#x}) : Creating keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(res.viewkeys())))
         for key in res.viewkeys():
+            logging.debug(u"{:s}.create_refs({:#x}) : Increasing refcount for {!s} at {:s} {:#x}.".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
             internal.comment.globals.inc(interface.range.start(fn), key)
-            logging.debug(u"{:s}.create_refs({:#x}) : Increasing refcount for {!s} at {:s} for keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', utils.string.repr(res.viewkeys())))
         return
 
     @classmethod
     def _delete_refs(cls, fn, res):
+        logging.debug(u"{:s}.delete_refs({:#x}) : Deleting keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(res.viewkeys())))
         for key in res.viewkeys():
+            logging.debug(u"{:s}.delete_refs({:#x}) : Decreasing refcount for {!s} at {:s} {:#x}.".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
             internal.comment.globals.dec(interface.range.start(fn), key)
-            logging.debug(u"{:s}.delete_refs({:#x}) : Decreasing refcount for {!s} at {:s} for keys ({!s}).".format('.'.join((__name__, cls.__name__)), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', utils.string.repr(res.viewkeys())))
         return
 
     @classmethod

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -53,11 +53,6 @@ class commentbase(object):
 
 class address(commentbase):
     @classmethod
-    def _is_repeatable(cls, ea):
-        f = idaapi.get_func(ea)
-        return True if f is None else False
-
-    @classmethod
     def _update_refs(cls, ea, old, new):
         f = idaapi.get_func(ea)
         logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
@@ -109,7 +104,7 @@ class address(commentbase):
 
             # now fix the comment the user typed
             if (newea, nrpt, none) == (ea, rpt, None):
-                ncmt, repeatable = utils.string.of(idaapi.get_cmt(ea, rpt)), cls._is_repeatable(ea)
+                ncmt = utils.string.of(idaapi.get_cmt(ea, rpt))
 
                 if (ncmt or '') != new:
                     logging.warn(u"{:s}.event() : Comment from event at address {:#x} is different from database. Expected comment ({!s}) is different from current comment ({!s}).".format('.'.join((__name__, cls.__name__)), ea, utils.string.repr(new), utils.string.repr(ncmt)))
@@ -117,7 +112,7 @@ class address(commentbase):
                 ## if the comment is of the correct format, then we can simply
                 ## write the comment to the given address
                 if internal.comment.check(new):
-                    idaapi.set_cmt(ea, utils.string.to(new), repeatable)
+                    idaapi.set_cmt(ea, utils.string.to(new), rpt)
 
                 ## if there's a comment to set, then assign it to the requested
                 ## address
@@ -141,8 +136,6 @@ class address(commentbase):
             new = utils.string.of(idaapi.get_cmt(newea, nrpt))
             n = internal.comment.decode(new)
             cls._create_refs(newea, n)
-
-            continue
         return
 
     @classmethod
@@ -328,8 +321,6 @@ class globals(commentbase):
             new = utils.string.of(idaapi.get_func_cmt(newfn, nrpt))
             n = internal.comment.decode(new)
             cls._create_refs(newfn, n)
-
-            continue
         return
 
     @classmethod

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -217,25 +217,26 @@ class address(commentbase):
         fn = idaapi.get_func(ea)
         rt, _ = internal.interface.addressOfRuntimeOrStatic(fn) if fn else (False, None)
 
-        # if we're in a function, then clear our contents.
+        # if we're in a function but not a runtime-linked one, then we need to
+        # to clear our contents here.
         if fn and not rt:
             internal.comment.contents.set_address(ea, 0)
 
-        # otherwise, just clear the tags globally
+        # otherwise, we can simply clear the tags globally
         else:
             internal.comment.globals.set_address(ea, 0)
 
-        # simply grab the comment and update its refs
+        # grab the comment and then re-create its references.
         res = internal.comment.decode(cmt)
         if res:
             cls._create_refs(ea, res)
 
-        # otherwise, there's nothing to do if its empty
+        # otherwise, there's nothing to do since it's empty.
         else:
             return
 
-        # and then re-write it back to its address, but not before disabling
-        # our hooks that brought is here so that we can avoid any re-entrancy issues.
+        # re-encode the comment back to its address, but not before disabling
+        # our hooks that brought us here so that we can avoid any re-entrancy issues.
         ui.hook.idb.disable('cmt_changed')
         try:
             idaapi.set_cmt(ea, utils.string.to(internal.comment.encode(res)), repeatable_cmt)
@@ -244,7 +245,7 @@ class address(commentbase):
         finally:
             ui.hook.idb.enable('cmt_changed')
 
-        # and then leave because hopefully things were updated properly
+        # and then leave because this should've updated things properly.
         return
 
 class globals(commentbase):


### PR DESCRIPTION
This PR changes the way that tags work so that they can be included in either repeatable or non-repeatable comments without issue. Prior to this, we were forcing which type the user was using when defining their comment (and hence their tags). This was being done in two ways. The first way was to check which comment was being used during the encoding of a tag, and if the wrong type was being used then the logic would be to move the contents from the wrong comment location to the correct one. The second way this was forced was by hooking when comments were being defined by the user, and then manually rewriting them to the correct comment location. This meant that the tag cache would keep track of only the tags that were encoded to the right place which resulted in the cache becoming desynchronized until the user modified the comment again.

The PR remedies the aforementioned logic by trying to determine which comment type the user's tag was written to. If the tag was not found in either comment location, then we explicitly choose the correct one that makes sense for the given address. When tags are fetched they are still combined like before, but the tags from the correct comment type are now given priority. Also, when writing or erasing tags we're now guarding against event hooks being triggered to prevent the references in the cache being tampered with more than once.

This PR also changes the way the tag cache works in that now it keeps track of tags that have been encoded in both types of comments at a given address. This means that if a user has more than one comment type defined, then the name cache will include the count for all tag names with duplicates, and the address cache will be the sum of all of the tags that have been defined at both locations.

This closes issue #71 