### PR TITLE
Fixed the way internal submodules and api modules are imported by modifying their loader.

### DIFF
--- a/base/_exceptions.py
+++ b/base/_exceptions.py
@@ -1,4 +1,4 @@
-import exceptions as E
+import builtins as E
 
 class UnicodeException(E.BaseException):
     """

--- a/base/_exceptions.py
+++ b/base/_exceptions.py
@@ -213,7 +213,7 @@ class UnknownPrototypeError(UnicodeException, E.LookupError):
     The requested prototype does not match any of the ones that are available.
     """
 
-class DuplicateItemError(E.DisassemblerError, E.NameError):
+class DuplicateItemError(DisassemblerError, E.NameError):
     """
     The requested command has failed due to a duplicate item.
     """

--- a/idapythonrc.py
+++ b/idapythonrc.py
@@ -24,19 +24,28 @@ root = idaapi.get_user_idadir()
 sys.path.remove(root)
 
 class internal_api(object):
-    """Meta-path base-class for an api that's based on files within a directory"""
+    """
+    Loader base-class for any api that's based on files contained within a directory.
+    """
     os, imp, fnmatch = os, imp, fnmatch
     def __init__(self, directory, **attributes):
+        '''Initialize the api using the contents within the specified `directory`.'''
         self.path = self.os.path.realpath(directory)
         [ setattr(self, name, attribute) for name, attribute in attributes.items() ]
 
     ### Api operations
     def load_api(self, path):
+        '''Load the specified `path` into a module that can be used.'''
         path, filename = self.os.path.split(path)
         name, _ = self.os.path.splitext(filename)
-        return self.imp.find_module(name, [ path ])
+        return self.imp.find_module(name, [path])
 
     def iterate_api(self, include='*.py', exclude=None):
+        """Iterate through all of the files in the directory specified when initializing the loader.
+
+        The `include` string is a glob that specifies which files are part of the loader's api.
+        If the `exclude` glob is specified, then exclude files that match it from the loader api.
+        """
         result = []
         for filename in self.fnmatch.filter(self.os.listdir(self.path), include):
             if exclude and self.fnmatch.fnmatch(filename, exclude):
@@ -51,16 +60,18 @@ class internal_api(object):
         return
 
     def new_api(self, modulename, path):
+        '''Load the file found at `path` into the specified `modulename`.'''
         file, path, description = self.load_api(path)
         try:
             return self.imp.load_module(modulename, file, path, description)
         finally: file.close()
 
     ### Module operations
-    def new_module(self, fullname, doc=None):
+    def new_module(self, fullname, documentation=None):
+        '''Create a new module (empty) with the specified `fullname` and the provided `documentation`.'''
         res = self.imp.new_module(fullname)
         res.__package__ = fullname
-        res.__doc__ = doc or ''
+        res.__doc__ = documentation or ''
         return res
 
     def find_module(self, fullname, path=None):
@@ -70,55 +81,68 @@ class internal_api(object):
         raise NotImplementedError
 
 class internal_path(internal_api):
+    """
+    Loader class which provides all api composed of all of the files within a directory
+    as modules that can always be imported from anywhere.
+    """
     def __init__(self, path, **attrs):
+        '''Initialize the loader using the files from the directory specified by `path`.'''
         super(internal_path, self).__init__(path)
         attrs.setdefault('include', '*.py')
         self.attrs, self.cache = attrs, { name : path for name, path in self.iterate_api(**attrs) }
 
     def find_module(self, fullname, path=None):
+        '''If the module with the name `fullname` matches one of the files handled by our api, then act as their loader.'''
         return self if path is None and fullname in self.cache else None
 
     def load_module(self, fullname):
+        '''Iterate through all of the modules that we can handle, and then load it if we've been asked.'''
         self.cache = { name : path for name, path in self.iterate_api(**self.attrs) }
+        if fullname not in self.cache:
+            raise ImportError("Path-loader ({:s}) was unable to find a module named {:s}".format(self.path, fullname))
         return self.new_api(fullname, self.cache[fullname])
 
 class internal_submodule(internal_api):
+    """
+    Loader class which provides an api composed of all of the files within a
+    directory, and binds them to a module which is used to access them.
+    """
     sys = sys
     def __init__(self, __name__, path, **attrs):
+        '''Initialize the loader using `__name__` as the name of the submodule using the files underneath the directory `path`.'''
         super(internal_submodule, self).__init__(path)
         attrs.setdefault('include', '*.py')
         self.__name__, self.attrs = __name__, attrs
 
     def find_module(self, fullname, path=None):
+        '''If the module with the name `fullname` matches our submodule name, then act as its loader.'''
         return self if path is None and fullname == self.__name__ else None
 
-    def filter_module(self, filename):
-        return self.fnmatch.fnmatch(filename, self.attrs['include']) and ('exclude' in self.attrs and not self.fnmatch.fnmatch(filename, self.attrs['exclude']))
-
-    def fetch_module(self, name):
-        cache = { name : path for name, path in self.iterate_api(**self.attrs) }
-        return self.new_api(name, cache[name])
-
     def new_api(self, modulename, path):
+        '''Load the file found at the specified `path` as a submodule with the specified `modulename`.'''
         cls, fullname = self.__class__, '.'.join([self.__name__, modulename])
         res = super(cls, self).new_api(fullname, path)
         res.__package__ = self.__name__
         return res
 
     def load_module(self, fullname):
+        '''Iterate through all of the modules that we can handle, load the submodule with them, and return it.'''
         module = self.sys.modules[fullname] = self.new_module(fullname)
         # FIXME: make module a lazy-loaded object for fetching module-code on-demand
 
+        # Build a temporary cache for the module names and paths to load the api,
+        # and use them to build their documentation.
         cache = { name : path for name, path in self.iterate_api(**self.attrs) }
         module.__doc__ = '\n'.join("{:s} -- {:s}".format(name, path) for name, path in sorted(cache.items()))
 
+        # Load each module composing the api, and attach it to the returned submodule.
         for name, path in cache.items():
             try:
                 res = self.new_api(name, path)
                 modulename = '.'.join([res.__package__, name])
 
             except Exception:
-                __import__('logging').warn("{:s} : Unable to import module {:s} from {!r}".format(self.__name__, name, path), exc_info=True)
+                __import__('logging').warning("{:s} : Unable to import module {:s} from {!s}".format(self.__name__, name, path), exc_info=True)
 
             else:
                 setattr(module, name, res)
@@ -126,18 +150,29 @@ class internal_submodule(internal_api):
         return module
 
 class internal_object(object):
+    """
+    Loader class which will simply expose an object instance as the module.
+    """
     def __init__(self, __name__, object):
+        '''Initialize the loader with the specified `__name__` and returning the provided `object` as its module.'''
         self.__name__, self.object = __name__, object
 
     def find_module(self, fullname, path=None):
+        '''If the module being searched for matches our `fullname`, then act as its loader.'''
         return self if path is None and fullname == self.__name__ else None
 
     def load_module(self, fullname):
+        '''Return the specific object for the module specified by `fullname`.'''
         if fullname != self.__name__:
             raise ImportError("Loader {:s} was not able to find a module named {:s}".format(self.__name__, fullname))
         return self.object
 
 class plugin_module(object):
+    """
+    Loader class which iterates through all of the files in a directory, and
+    manually initializes each plugin similar to the way `idaapi.plugin_t` is
+    supposed to be initialized.
+    """
     def __init__(self, path, **attrs):
         # FIXME: go through all files in plugin/ and call PLUGIN_ENTRY() on each module
         #        this should return an idaapi.plugin_t.
@@ -156,25 +191,26 @@ class plugin_module(object):
         # idaapi.require
         pass
 
-## ida's native api
-if sys.platform == 'darwin':
+## IDA's native lower-level api
+if sys.platform in {'darwin'}:
     sys.meta_path.append( internal_object('ida', library(idaapi.idadir('libida.dylib'))) )
-elif sys.platform in 'linux2':
-    sys.meta_path.append( internal_object('ida', library('libida.so')) )
-elif sys.platform == 'win32':
+
+elif sys.platform in {'linux2'}:
+    sys.meta_path.append( internal_object('ida', library("libida{:s}.so".format('' if idaapi.BADADDR < 0x100000000 else '64'))) )
+
+elif sys.platform in {'win32'}:
     if __import__('os').path.exists(idaapi.idadir('ida.wll')):
         sys.meta_path.append( internal_object('ida', library(idaapi.idadir('ida.wll'))) )
-    elif idaapi.BADADDR >= 0x100000000:
-        sys.meta_path.append( internal_object('ida', library(idaapi.idadir("ida{:s}.dll".format("64")))) )
     else:
-        sys.meta_path.append( internal_object('ida', library(idaapi.idadir("ida{:s}.dll".format("")))) )
-else:
-    raise NotImplementedError
+        sys.meta_path.append( internal_object('ida', library(idaapi.idadir("ida{:s}.dll".format('' if idaapi.BADADDR < 0x100000000 else '64')))) )
 
-# private api
+else:
+    __import__('logging').warning("{:s} : Unable to successfully load IDA's native api with ctypes.".format(__name__))
+
+## private (internal) api
 sys.meta_path.append( internal_submodule('internal', os.path.join(root, 'base'), include='_*.py') )
 
-# public api
+## public api
 sys.meta_path.append( internal_path(os.path.join(root, 'base'), exclude='_*.py') )
 sys.meta_path.append( internal_path(os.path.join(root, 'misc')) )
 
@@ -182,50 +218,60 @@ sys.meta_path.append( internal_path(os.path.join(root, 'misc')) )
 for _ in ('custom', 'app'):
     sys.meta_path.append( internal_submodule(_, os.path.join(root, _)) )
 
-# temporarily root namespace
+# temporarily load the root namespace
 __root__ = imp.load_source('__root__', os.path.join(root, '__root__.py'))
 
-# empty out idapython's namespace
-map(globals().pop, {_ for _ in globals().copy().viewkeys() if not _.startswith('__')})
+# empty out IDAPython's namespace so that we can replace it
+map(globals().pop, {symbol for symbol in globals().copy() if not symbol.startswith('__')})
 
-# re-populate with a default namespace and empty out our variable
-globals().update({_ for _ in __root__.__dict__.viewitems() if not _[0].startswith('__')})
-globals().pop('__root__')
+# re-populate with a default namespace and remove our variable that contained it
+globals().update({symbol : value for symbol, value in __root__.__dict__.items() if not symbol.startswith('__')})
+del(__root__)
 
 # try and execute our user's idapythonrc.py
 try:
+    import os
+    path, filename = None, '.idapythonrc.py'
+
     try:
         # execute user's .pythonrc and .idapythonrc in one go
         if __import__('user').home:
-            execfile(__import__('os').path.join(__import__('user').home, '.idapythonrc.py'))
+            path = __import__('user').home
+            execfile(os.path.join(path, filename))
 
     except ImportError:
         # otherwise try to figure it out without tainting the namespace
         if __import__('os').getenv('HOME', default=None) is not None:
-            execfile(__import__('os').path.join(__import__('os').getenv('HOME'), '.idapythonrc.py'))
+            path = os.getenv('HOME')
+            execfile(os.path.join(path, filename))
         elif __import__('os').getenv('USERPROFILE', default=None) is not None:
-            execfile(__import__('os').path.join(__import__('os').getenv('USERPROFILE'), '.idapythonrc.py'))
+            path = os.getenv('USERPROFILE')
+            execfile(os.path.join(path, filename))
         else:
             raise OSError('Unable to determine the user\'s home directory.')
         pass
 
 except IOError:
-    __import__('logging').warn('No .idapythonrc.py file found in the user\'s home directory.')
+    __import__('logging').warning("No {:s} file found in the user's home directory ({!s}).".format(filename, path))
 
-except Exception, e:
-    print("Unexpected exception raised while trying to execute `~/.idapythonrc.py`.")
-    __import__('traceback').print_exc()
+except Exception:
+    __import__('logging').warning("Unexpected exception raised while trying to execute `{!s}`.".format(os.path.join(path or '~', filename)), exc_info=True)
+
+finally:
+    del(filename)
+    del(path)
+    del(os)
 
 ## stupid fucking idapython hax
 # prevent idapython from trying to write its banner to the message window since we called it up above.
 print_banner = lambda: None
 
 # find the frame that fucks with our sys.modules, and save it for later
-_ = __import__('sys')._getframe()
-while _.f_code.co_name != 'IDAPython_ExecScript':
-    _ = _.f_back
+frame = __import__('sys')._getframe()
+while frame.f_code.co_name != 'IDAPython_ExecScript':
+    frame = frame.f_back
 
 # inject our current sys.modules state into IDAPython_ExecScript's state if it's the broken version
-if 'basemodules' in _.f_locals:
-    _.f_locals['basemodules'].update(__import__('sys').modules)
-del _
+if 'basemodules' in frame.f_locals:
+    frame.f_locals['basemodules'].update(__import__('sys').modules)
+del(frame)

--- a/idapythonrc.py
+++ b/idapythonrc.py
@@ -237,16 +237,16 @@ try:
         # execute user's .pythonrc and .idapythonrc in one go
         if __import__('user').home:
             path = __import__('user').home
-            execfile(os.path.join(path, filename))
+            exec(open(os.path.join(path, filename)).read())
 
     except ImportError:
         # otherwise try to figure it out without tainting the namespace
         if __import__('os').getenv('HOME', default=None) is not None:
             path = os.getenv('HOME')
-            execfile(os.path.join(path, filename))
+            exec(open(os.path.join(path, filename)).read())
         elif __import__('os').getenv('USERPROFILE', default=None) is not None:
             path = os.getenv('USERPROFILE')
-            execfile(os.path.join(path, filename))
+            exec(open(os.path.join(path, filename)).read())
         else:
             raise OSError('Unable to determine the user\'s home directory.')
         pass


### PR DESCRIPTION
This PR fixes the way that the submodule and api modules are imported so that their names and packages are correct. Previously, the submodules could actually be imported from anywhere. This was due to a bug that occurred due to the loaders manually tampering with the `sys.modules` dictionary. This actually allowed the `internal.exceptions` module to work recursively which shouldn't have been possible.

The was fixed by removing all logic that tampered with `sys.modules` instead only allowing the `imp.load_module` function to maintain the responsibility. After refactoring the logic to fix that issue, the `internal.exceptions` module needed to be fixed which involved fixing a type-o and replacing the recursive import with the `builtins` module. A whole bunch of documentation was also added to the loaders and the `idapythonrc.py` script itself.