### PR TITLE
Replaced all types that are either missing or deprecated in Python3 with suitable alternatives that are still compatible with Python2.

### DIFF
--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1341,7 +1341,7 @@ class ref_t(namedtypedtuple):
     optional as not all references will provide it.
     """
     _fields = ('address', 'opnum', 'reftype')
-    _types = (six.integer_types, (six.integer_types, types.NoneType), reftype_t)
+    _types = (six.integer_types, (six.integer_types, None.__class__), reftype_t)
 
     def __repr__(self):
         cls = self.__class__

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1127,7 +1127,7 @@ class register_t(symbol_t):
         return "<class '{:s}' index={:d} dtype={:s} name='{!s}' position={:d}{:+d}>".format(cls.__name__, self.id, dt, internal.utils.string.escape(self.name, '\''), self.position, self.size)
 
     def __eq__(self, other):
-        if isinstance(other, basestring):
+        if isinstance(other, six.string_types):
             return self.name.lower() == other.lower()
         elif isinstance(other, register_t):
             return self is other
@@ -1186,7 +1186,7 @@ class regmatch(object):
         _instruction = sys.modules.get('instruction', __import__('instruction'))
 
         # convert any regs that are strings into their correct object type
-        regs = { _instruction.architecture.by_name(r) if isinstance(r, basestring) else r for r in regs }
+        regs = { _instruction.architecture.by_name(r) if isinstance(r, six.string_types) else r for r in regs }
 
         # returns an iterable of bools that returns whether r is a subset of any of the registers in `regs`.
         match = lambda r, regs=regs: any(itertools.imap(r.relatedQ, regs))

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -204,8 +204,8 @@ class multicase(object):
 
         # validate type arguments
         for n, t in t_args.iteritems():
-            if not isinstance(t, (types.TypeType, types.TupleType)) and t not in {callable}:
-                error_keywords = ("{:s}={!s}".format(n, t.__name__ if isinstance(t, types.TypeType) or t in {callable} else '|'.join(t_.__name__ for t_ in t) if hasattr(t, '__iter__') else "{!r}".format(t)) for n, t in t_args.iteritems())
+            if not isinstance(t, (builtins.type, builtins.tuple)) and t not in {callable}:
+                error_keywords = ("{:s}={!s}".format(n, t.__name__ if isinstance(t, builtins.type) or t in {callable} else '|'.join(t_.__name__ for t_ in t) if hasattr(t, '__iter__') else "{!r}".format(t)) for n, t in t_args.iteritems())
                 raise internal.exceptions.InvalidParameterError(u"@{:s}({:s}) : The value ({!s}) specified for parameter \"{:s}\" is not a supported type.".format('.'.join([__name__, cls.__name__]), ', '.join(error_keywords), t, string.escape(n, '"')))
             continue
 
@@ -214,12 +214,12 @@ class multicase(object):
             for c in other:
                 cls.ex_function(c)
         except:
-            error_keywords = ("{:s}={!s}".format(n, t.__name__ if isinstance(t, types.TypeType) or t in {callable} else '|'.join(t_.__name__ for t_ in t) if hasattr(t, '__iter__') else "{!r}".format(t)) for n, t in t_args.iteritems())
+            error_keywords = ("{:s}={!s}".format(n, t.__name__ if isinstance(t, builtins.type) or t in {callable} else '|'.join(t_.__name__ for t_ in t) if hasattr(t, '__iter__') else "{!r}".format(t)) for n, t in t_args.iteritems())
             raise internal.exceptions.InvalidParameterError(u"@{:s}({:s}) : The specified callable{:s} {!r} {:s} not of a valid type.".format('.'.join([__name__, cls.__name__]), ', '.join(error_keywords), '' if len(other) == 1 else 's', other, 'is' if len(other) == 1 else 'are'))
 
         # throw an exception if we were given an unexpected number of arguments
         if len(other) > 1:
-            error_keywords = ("{:s}={!s}".format(n, t.__name__ if isinstance(t, types.TypeType) or t in {callable} else '|'.join(t_.__name__ for t_ in t) if hasattr(t, '__iter__') else "{!r}".format(t)) for n, t in t_args.iteritems())
+            error_keywords = ("{:s}={!s}".format(n, t.__name__ if isinstance(t, builtins.type) or t in {callable} else '|'.join(t_.__name__ for t_ in t) if hasattr(t, '__iter__') else "{!r}".format(t)) for n, t in t_args.iteritems())
             raise internal.exceptions.InvalidParameterError(u"@{:s}({:s}) : More than one callable ({:s}) was specified to add a case to. Refusing to add cases to more than one callable.".format('.'.join([__name__, cls.__name__]), ', '.join(error_keywords), ', '.join("\"{:s}\"".format(string.escape(c.co_name if isinstance(c, types.CodeType) else c.__name__, '"')) for c in other)))
         return result
 
@@ -260,7 +260,7 @@ class multicase(object):
                     continue
 
                 param_type = parameters[item]
-                if isinstance(param_type, types.TypeType) or param_type in {callable}:
+                if isinstance(param_type, builtins.type) or param_type in {callable}:
                     yield item, param_type.__name__
                 elif hasattr(param_type, '__iter__'):
                     yield item, '|'.join(t.__name__ for t in flatten(param_type))
@@ -379,7 +379,7 @@ class multicase(object):
             return lambda f: type(n)(f)
         if isinstance(n, types.InstanceType):
             return lambda f: types.InstanceType(type(n), dict(f.__dict__))
-        if isinstance(n, (types.TypeType, types.ClassType)):
+        if isinstance(n, (builtins.type, types.ClassType)):
             return lambda f: type(n)(n.__name__, n.__bases__, dict(f.__dict__))
         raise internal.exceptions.InvalidTypeOrValueError(type(n))
 
@@ -1006,7 +1006,7 @@ class wrap(object):
             return lambda method, mt=callable.__class__: types.InstanceType(mt, dict(method.__dict__))
 
         # otherwise if it's a class or a type, then we just need to create the object with its bases
-        elif isinstance(n, (types.TypeType, types.ClassType)):
+        elif isinstance(n, (builtins.type, types.ClassType)):
             return lambda method, t=callable.__class__, name=callable.__name__, bases=callable.__bases__: t(name, bases, dict(method.__dict__))
 
         # if we get here, then we have no idea what kind of type `callable` is

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -436,7 +436,7 @@ class matcher(object):
     def __attrib__(self, *attribute):
         if not attribute:
             return lambda n: n
-        res = [(operator.attrgetter(a) if isinstance(a, basestring) else a) for a in attribute]
+        res = [(operator.attrgetter(a) if isinstance(a, six.string_types) else a) for a in attribute]
         return lambda o: tuple(x(o) for x in res) if len(res) > 1 else res[0](o)
     def attribute(self, type, *attribute):
         attr = self.__attrib__(*attribute)
@@ -756,7 +756,7 @@ class string(object):
         All unicode strings are encoded to UTF-8 in order to guarantee
         the resulting string can be emitted.
         """
-        if isinstance(item, basestring):
+        if isinstance(item, six.string_types):
             res = cls.escape(item, '\'')
             if all(six.byte2int(ch) < 0x100 for ch in item):
                 return "'{:s}'".format(res)

--- a/base/database.py
+++ b/base/database.py
@@ -1015,7 +1015,7 @@ def name(ea, **flags):
 def name(string, *suffix, **flags):
     '''Renames the current address to `string`.'''
     return name(ui.current.address(), string, *suffix, **flags)
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def name(none, **flags):
     '''Removes the name at the current address.'''
     return name(ui.current.address(), none or '', **flags)
@@ -1127,7 +1127,7 @@ def name(ea, string, *suffix, **flags):
 
     # otherwise, we use the name_without closure to apply it
     return name_outside(ea, string, flag)
-@utils.multicase(ea=six.integer_types, none=types.NoneType)
+@utils.multicase(ea=six.integer_types, none=None.__class__)
 def name(ea, none, **flags):
     '''Removes the name defined at the address `ea`.'''
     return name(ea, none or '', **flags)
@@ -1136,7 +1136,7 @@ def name(ea, none, **flags):
 def color():
     '''Return the rgb color at the current address.'''
     return color(ui.current.address())
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def color(none):
     '''Remove the color from the current address.'''
     return color(ui.current.address(), None)
@@ -1146,7 +1146,7 @@ def color(ea):
     res = idaapi.get_item_color(interface.address.inside(ea))
     b, r = (res&0xff0000)>>16, res&0x0000ff
     return None if res == 0xffffffff else (r<<16)|(res&0x00ff00)|b
-@utils.multicase(ea=six.integer_types, none=types.NoneType)
+@utils.multicase(ea=six.integer_types, none=None.__class__)
 def color(ea, none):
     '''Remove the color at the address `ea`.'''
     return idaapi.set_item_color(interface.address.inside(ea), 0xffffffff)
@@ -1175,7 +1175,7 @@ def comment(ea, **repeatable):
 def comment(string, **repeatable):
     '''Set the comment at the current address to `string`.'''
     return comment(ui.current.address(), string, **repeatable)
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def comment(none, **repeatable):
     '''Remove the comment at the current address.'''
     return comment(ui.current.address(), none or '', **repeatable)
@@ -1191,7 +1191,7 @@ def comment(ea, string, **repeatable):
     if not ok:
         raise E.DisassemblerError(u"{:s}.comment({:#x}, {!r}{:s}) : Unable to call `idaapi.set_cmt({:#x}, \"{:s}\", {!s})`.".format(__name__, ea, string, u", {:s}".format(utils.string.kwargs(repeatable)) if repeatable else '', ea, utils.string.escape(string, '"'), repeatable.get('repeatable', False)))
     return res
-@utils.multicase(ea=six.integer_types, none=types.NoneType)
+@utils.multicase(ea=six.integer_types, none=None.__class__)
 def comment(ea, none, **repeatable):
     """Remove the comment at the address `ea`.
 
@@ -1609,11 +1609,11 @@ def tag(ea, key, value):
 
     # we can now return what the user asked for.
     return res
-@utils.multicase(key=six.string_types, none=types.NoneType)
+@utils.multicase(key=six.string_types, none=None.__class__)
 def tag(key, none):
     '''Remove the tag identified by `key` from the current address.'''
     return tag(ui.current.address(), key, none)
-@utils.multicase(ea=six.integer_types, key=six.string_types, none=types.NoneType)
+@utils.multicase(ea=six.integer_types, key=six.string_types, none=None.__class__)
 @utils.string.decorate_arguments('key')
 def tag(ea, key, none):
     '''Removes the tag identified by `key` at the address `ea`.'''
@@ -3083,7 +3083,7 @@ class type(object):
                 raise E.InvalidTypeOrValueError(u"{:s}.info({:#x}) : Unable to parse the returned type declaration ({!s}).".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(info_s)))
             return ti
         return ti
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     def __new__(cls, none):
         '''Remove the typeinfo from the current address.'''
         return cls(ui.current.address(), None)
@@ -3114,7 +3114,7 @@ class type(object):
 
         # Return the typeinfo that was applied to the specified address.
         return cls(ea)
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     def __new__(cls, ea, none):
         '''Remove the typeinfo from the address `ea`.'''
         ti = idaapi.tinfo_t()
@@ -4216,7 +4216,7 @@ def mark():
     '''Return the mark at the current address.'''
     _, res = marks.by_address(ui.current.address())
     return res
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def mark(none):
     '''Remove the mark at the current address.'''
     return mark(ui.current.address(), None)
@@ -4230,7 +4230,7 @@ def mark(ea):
 def mark(description):
     '''Set the mark at the current address to the specified `description`.'''
     return mark(ui.current.address(), description)
-@utils.multicase(ea=six.integer_types, none=types.NoneType)
+@utils.multicase(ea=six.integer_types, none=None.__class__)
 def mark(ea, none):
     '''Erase the mark at address `ea`.'''
     try:
@@ -4491,7 +4491,7 @@ class extra(object):
     def prefix(cls, string):
         '''Set the prefixed comment at the current address to the specified `string`.'''
         return cls.__set_prefix__(ui.current.address(), string)
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     @classmethod
     def prefix(cls, none):
         '''Delete the prefixed comment at the current address.'''
@@ -4506,7 +4506,7 @@ class extra(object):
     def prefix(cls, ea, string):
         '''Set the prefixed comment at address `ea` to the specified `string`.'''
         return cls.__set_prefix__(ea, string)
-    @utils.multicase(ea=six.integer_types, none=types.NoneType)
+    @utils.multicase(ea=six.integer_types, none=None.__class__)
     @classmethod
     def prefix(cls, ea, none):
         '''Delete the prefixed comment at address `ea`.'''
@@ -4522,7 +4522,7 @@ class extra(object):
     def suffix(cls, string):
         '''Set the suffixed comment at the current address to the specified `string`.'''
         return cls.__set_suffix__(ui.current.address(), string)
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     @classmethod
     def suffix(cls, none):
         '''Delete the suffixed comment at the current address.'''
@@ -4537,7 +4537,7 @@ class extra(object):
     def suffix(cls, ea, string):
         '''Set the suffixed comment at address `ea` to the specified `string`.'''
         return cls.__set_suffix__(ea, string)
-    @utils.multicase(ea=six.integer_types, none=types.NoneType)
+    @utils.multicase(ea=six.integer_types, none=None.__class__)
     @classmethod
     def suffix(cls, ea, none):
         '''Delete the suffixed comment at address `ea`.'''

--- a/base/database.py
+++ b/base/database.py
@@ -296,7 +296,7 @@ class functions(object):
             ch = idaapi.get_next_func(interface.range.start(ch))
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def iterate(cls, string):
@@ -312,7 +312,7 @@ class functions(object):
             iterable = cls.__matcher__.match(key, value, iterable)
         for item in iterable: yield item
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def list(cls, string):
@@ -386,7 +386,7 @@ class functions(object):
             ))
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def search(cls, string):
@@ -442,7 +442,7 @@ class segments(object):
             yield interface.range.bounds(seg)
         return
 
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def list(cls, name):
@@ -455,7 +455,7 @@ class segments(object):
         '''List all of the segments in the database that match the keyword specified by `type`.'''
         return segment.list(**type)
 
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def iterate(cls, name):
@@ -468,7 +468,7 @@ class segments(object):
         '''Iterate through all the segments defined in the database matching the keyword specified by `type`.'''
         return segment.__iterate__(**type)
 
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def search(cls, name):
@@ -662,7 +662,7 @@ class names(object):
             yield tuple(f(x) for f, x in res)
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def __iterate__(cls, string):
@@ -676,7 +676,7 @@ class names(object):
             iterable = cls.__matcher__.match(key, value, iterable)
         for item in iterable: yield item
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def iterate(cls, string):
@@ -692,7 +692,7 @@ class names(object):
             yield ea, utils.string.of(name)
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def list(cls, string):
@@ -727,7 +727,7 @@ class names(object):
             six.print_(u"[{:>{:d}d}] {:#0{:d}x} {:s}".format(index, int(cindex), ea, int(caddr), utils.string.of(name)))
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def search(cls, string):
@@ -842,13 +842,13 @@ class search(object):
         return res
     bybytes = utils.alias(by_bytes, 'search')
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @staticmethod
     @utils.string.decorate_arguments('string')
     def by_regex(string, **options):
         '''Search through the database at the current address for the regex matched by `string`.'''
         return search.by_regex(ui.current.address(), string, **options)
-    @utils.multicase(ea=six.integer_types, string=basestring)
+    @utils.multicase(ea=six.integer_types, string=six.string_types)
     @staticmethod
     @utils.string.decorate_arguments('string')
     def by_regex(ea, string, **options):
@@ -869,13 +869,13 @@ class search(object):
         return res
     byregex = utils.alias(by_regex, 'search')
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @staticmethod
     @utils.string.decorate_arguments('string')
     def by_text(string, **options):
         '''Search through the database at the current address for the text matched by `string`.'''
         return search.by_text(ui.current.address(), string, **options)
-    @utils.multicase(ea=six.integer_types, string=basestring)
+    @utils.multicase(ea=six.integer_types, string=six.string_types)
     @staticmethod
     @utils.string.decorate_arguments('string')
     def by_text(ea, string, **options):
@@ -896,13 +896,13 @@ class search(object):
         return res
     bytext = by_string = bystring = utils.alias(by_text, 'search')
 
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @staticmethod
     @utils.string.decorate_arguments('name')
     def by_name(name, **options):
         '''Search through the database at the current address for the symbol `name`.'''
         return search.by_name(ui.current.address(), name, **options)
-    @utils.multicase(ea=six.integer_types, name=basestring)
+    @utils.multicase(ea=six.integer_types, name=six.string_types)
     @staticmethod
     @utils.string.decorate_arguments('name')
     def by_name(ea, name, **options):
@@ -971,7 +971,7 @@ byname = by_name = utils.alias(search.by_name, 'search')
 
 def go(ea):
     '''Jump to the specified address at `ea`.'''
-    if isinstance(ea, basestring):
+    if isinstance(ea, six.string_types):
         ea = search.by_name(None, ea)
     idaapi.jumpto(interface.address.inside(ea))
     return ea
@@ -1010,7 +1010,7 @@ def name(ea, **flags):
 
     # return the name at the specified address or not
     return utils.string.of(aname) or None
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string', 'suffix')
 def name(string, *suffix, **flags):
     '''Renames the current address to `string`.'''
@@ -1019,7 +1019,7 @@ def name(string, *suffix, **flags):
 def name(none, **flags):
     '''Removes the name at the current address.'''
     return name(ui.current.address(), none or '', **flags)
-@utils.multicase(ea=six.integer_types, string=basestring)
+@utils.multicase(ea=six.integer_types, string=six.string_types)
 @utils.string.decorate_arguments('string', 'suffix')
 def name(ea, string, *suffix, **flags):
     """Renames the address specified by `ea` to `string`.
@@ -1170,7 +1170,7 @@ def comment(ea, **repeatable):
 
     # return the string in a format the user can process
     return utils.string.of(res)
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def comment(string, **repeatable):
     '''Set the comment at the current address to `string`.'''
@@ -1179,7 +1179,7 @@ def comment(string, **repeatable):
 def comment(none, **repeatable):
     '''Remove the comment at the current address.'''
     return comment(ui.current.address(), none or '', **repeatable)
-@utils.multicase(ea=six.integer_types, string=basestring)
+@utils.multicase(ea=six.integer_types, string=six.string_types)
 @utils.string.decorate_arguments('string')
 def comment(ea, string, **repeatable):
     """Set the comment at the address `ea` to `string`.
@@ -1250,7 +1250,7 @@ class entries(object):
             yield ea
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def __iterate__(cls, string):
@@ -1264,7 +1264,7 @@ class entries(object):
             iterable = builtins.list(cls.__matcher__.match(key, value, iterable))
         for item in iterable: yield item
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def iterate(cls, string):
@@ -1327,7 +1327,7 @@ class entries(object):
             return cls.__entryname__(res)
         raise E.MissingTypeOrAttribute(u"{:s}.name({:#x}) : No entry point at specified address.".format('.'.join([__name__, cls.__name__]), ea))
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def list(cls, string):
@@ -1365,7 +1365,7 @@ class entries(object):
             six.print_(u"[{:{:d}d}] {:<#{:d}x} : {:s}{:s}".format(index, int(cindex), ea, 2 + int(caddr), '' if ea == ordinal else "({:#{:d}x}) ".format(ordinal, 2 + int(cindex)), cls.__entryname__(index)))
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def search(cls, string):
@@ -1405,26 +1405,26 @@ class entries(object):
         if entryname is None:
             raise E.MissingTypeOrAttribute(u"{:s}.new({:#x}) : Unable to determine name at address.".format( '.'.join([__name__, cls.__name__]), ea))
         return cls.new(ea, entryname, ordinal)
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def new(cls, name):
         '''Adds the current address as an entry point using `name` and the next available index as the ordinal.'''
         return cls.new(ui.current.address(), name, idaapi.get_entry_qty())
-    @utils.multicase(ea=six.integer_types, name=basestring)
+    @utils.multicase(ea=six.integer_types, name=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def new(cls, ea, name):
         '''Makes the specified address `ea` an entry point having the specified `name`.'''
         ordinal = idaapi.get_entry_qty()
         return cls.new(ea, name, ordinal)
-    @utils.multicase(name=basestring, ordinal=six.integer_types)
+    @utils.multicase(name=six.string_types, ordinal=six.integer_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def new(cls, name, ordinal):
         '''Adds an entry point with the specified `name` to the database using `ordinal` as its index.'''
         return cls.new(ui.current.address(), name, ordinal)
-    @utils.multicase(ea=six.integer_types, name=basestring, ordinal=six.integer_types)
+    @utils.multicase(ea=six.integer_types, name=six.string_types, ordinal=six.integer_types)
     @classmethod
     @utils.string.decorate_arguments('name')
     def new(cls, ea, name, ordinal):
@@ -1520,17 +1520,17 @@ def tag(ea):
 
     # now return what the user cares about
     return res
-@utils.multicase(key=basestring)
+@utils.multicase(key=six.string_types)
 @utils.string.decorate_arguments('key')
 def tag(key):
     '''Return the tag identified by `key` at the current address.'''
     return tag(ui.current.address(), key)
-@utils.multicase(key=basestring)
+@utils.multicase(key=six.string_types)
 @utils.string.decorate_arguments('key', 'value')
 def tag(key, value):
     '''Set the tag identified by `key` to `value` at the current address.'''
     return tag(ui.current.address(), key, value)
-@utils.multicase(ea=six.integer_types, key=basestring)
+@utils.multicase(ea=six.integer_types, key=six.string_types)
 @utils.string.decorate_arguments('key')
 def tag(ea, key):
     '''Returns the tag identified by `key` from address `ea`.'''
@@ -1538,7 +1538,7 @@ def tag(ea, key):
     if key in res:
         return res[key]
     raise E.MissingTagError(u"{:s}.tag({:#x}, {!r}) : Unable to read tag \"{:s}\" from address.".format(__name__, ea, key, utils.string.escape(key, '"')))
-@utils.multicase(ea=six.integer_types, key=basestring)
+@utils.multicase(ea=six.integer_types, key=six.string_types)
 @utils.string.decorate_arguments('key', 'value')
 def tag(ea, key, value):
     '''Set the tag identified by `key` to `value` at the address `ea`.'''
@@ -1609,11 +1609,11 @@ def tag(ea, key, value):
 
     # we can now return what the user asked for.
     return res
-@utils.multicase(key=basestring, none=types.NoneType)
+@utils.multicase(key=six.string_types, none=types.NoneType)
 def tag(key, none):
     '''Remove the tag identified by `key` from the current address.'''
     return tag(ui.current.address(), key, none)
-@utils.multicase(ea=six.integer_types, key=basestring, none=types.NoneType)
+@utils.multicase(ea=six.integer_types, key=six.string_types, none=types.NoneType)
 @utils.string.decorate_arguments('key')
 def tag(ea, key, none):
     '''Removes the tag identified by `key` at the address `ea`.'''
@@ -1681,7 +1681,7 @@ def tag(ea, key, none):
 # FIXME: consolidate the boolean querying logic into the utils module
 # FIXME: document this properly
 # FIXME: add support for searching global tags using the addressing cache
-@utils.multicase(tag=basestring)
+@utils.multicase(tag=six.string_types)
 @utils.string.decorate_arguments('And', 'Or')
 def select(tag, *And, **boolean):
     '''Query all of the global tags in the database for the specified `tag` and any others specified as `And`.'''
@@ -1730,7 +1730,7 @@ def select(**boolean):
 
 # FIXME: consolidate the boolean querying logic into the utils module
 # FIXME: document this properly
-@utils.multicase(tag=basestring)
+@utils.multicase(tag=six.string_types)
 @utils.string.decorate_arguments('tag', 'And', 'Or')
 def selectcontents(tag, *Or, **boolean):
     '''Query all function contents for the specified `tag` or any others specified as `Or`.'''
@@ -1878,7 +1878,7 @@ class imports(object):
             continue
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def iterate(cls, string):
@@ -1970,7 +1970,7 @@ class imports(object):
         iterable = (module for _, (module, _, _) in cls.__iterate__())
         return map(utils.string.of, { item for item in iterable if item})
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def list(cls, string):
@@ -2006,7 +2006,7 @@ class imports(object):
             six.print_(u"{:<#0{:d}x} : {:s}{:s}".format(ea, 2 + int(caddr), "{:>{:d}s} ".format(moduleordinal, maxmodule + cordinal) if module else ' ' * (1 + maxmodule + cordinal), name))
         return
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('string')
     def search(cls, string):
@@ -2511,22 +2511,22 @@ class address(object):
         return cls.nextF(ea, Fcref, count)
     prevcode, nextcode = utils.alias(prevcref, 'address'), utils.alias(nextcref, 'address')
 
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def prevreg(cls, reg, *regs, **modifiers):
         '''Return the previous address containing an instruction that uses `reg` or any one of the specified registers `regs`.'''
         return cls.prevreg(ui.current.address(), reg, *regs, **modifiers)
-    @utils.multicase(predicate=builtins.callable, reg=(basestring, interface.register_t))
+    @utils.multicase(predicate=builtins.callable, reg=(six.string_types, interface.register_t))
     @classmethod
     def prevreg(cls, predicate, reg, *regs, **modifiers):
         '''Return the previous address containing an instruction that uses `reg` or any one of the specified registers `regs` and matches `predicate`.'''
         return cls.prevreg(ui.current.address(), predicate, reg, *regs, **modifiers)
-    @utils.multicase(ea=six.integer_types, reg=(basestring, interface.register_t))
+    @utils.multicase(ea=six.integer_types, reg=(six.string_types, interface.register_t))
     @classmethod
     def prevreg(cls, ea, reg, *regs, **modifiers):
         '''Return the previous address from `ea` containing an instruction that uses `reg` or any one of the specified registers `regs`.'''
         return cls.prevreg(ea, utils.fconst(True), reg, *regs, **modifiers)
-    @utils.multicase(ea=six.integer_types, predicate=builtins.callable, reg=(basestring, interface.register_t))
+    @utils.multicase(ea=six.integer_types, predicate=builtins.callable, reg=(six.string_types, interface.register_t))
     @classmethod
     def prevreg(cls, ea, predicate, reg, *regs, **modifiers):
         '''Return the previous address from `ea` containing an instruction that uses `reg` or any one of the specified registers `regs` and matches `predicate`.'''
@@ -2577,22 +2577,22 @@ class address(object):
         modifiers['count'] = count - 1
         return cls.prevreg(res, predicate, *regs, **modifiers) if count > 1 else res
 
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def nextreg(cls, reg, *regs, **modifiers):
         '''Return the next address containing an instruction that uses `reg` or any one of the registers in `regs`.'''
         return cls.nextreg(ui.current.address(), reg, *regs, **modifiers)
-    @utils.multicase(predicate=builtins.callable, reg=(basestring, interface.register_t))
+    @utils.multicase(predicate=builtins.callable, reg=(six.string_types, interface.register_t))
     @classmethod
     def nextreg(cls, predicate, reg, *regs, **modifiers):
         '''Return the next address containing an instruction that matches `predicate` and uses `reg` or any one of the registers in `regs`.'''
         return cls.nextreg(ui.current.address(), predicate, reg, *regs, **modifiers)
-    @utils.multicase(ea=six.integer_types, reg=(basestring, interface.register_t))
+    @utils.multicase(ea=six.integer_types, reg=(six.string_types, interface.register_t))
     @classmethod
     def nextreg(cls, ea, reg, *regs, **modifiers):
         '''Return the next address from `ea` containing an instruction that uses `reg` or any one of the registers in `regs`.'''
         return cls.nextreg(ea, utils.fconst(True), reg, *regs, **modifiers)
-    @utils.multicase(ea=six.integer_types, predicate=builtins.callable, reg=(basestring, interface.register_t))
+    @utils.multicase(ea=six.integer_types, predicate=builtins.callable, reg=(six.string_types, interface.register_t))
     @classmethod
     def nextreg(cls, ea, predicate, reg, *regs, **modifiers):
         '''Return the next address from `ea` containing an instruction that matches `predicate` and uses `reg` or any one of the registers in `regs`.'''
@@ -3087,7 +3087,7 @@ class type(object):
     def __new__(cls, none):
         '''Remove the typeinfo from the current address.'''
         return cls(ui.current.address(), None)
-    @utils.multicase(info=(basestring, idaapi.tinfo_t))
+    @utils.multicase(info=(six.string_types, idaapi.tinfo_t))
     def __new__(cls, info):
         '''Apply the ``idaapi.tinfo_t`` typeinfo or typeinfo string in `info` to the current address.'''
         return cls(ui.current.address(), info)
@@ -3135,7 +3135,7 @@ class type(object):
 
         return result
 
-    @utils.multicase(ea=six.integer_types, info=basestring)
+    @utils.multicase(ea=six.integer_types, info=six.string_types)
     @utils.string.decorate_arguments('info')
     def __new__(cls, ea, info):
         '''Parse the typeinfo string in `info` to an ``idaapi.tinfo_t`` and apply it to the address `ea`.'''
@@ -4034,13 +4034,13 @@ class marks(object):
             yield ea, comment
         return
 
-    @utils.multicase(description=basestring)
+    @utils.multicase(description=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('description')
     def new(cls, description):
         '''Create a mark at the current address with the given `description`.'''
         return cls.new(ui.current.address(), description)
-    @utils.multicase(ea=six.integer_types, description=basestring)
+    @utils.multicase(ea=six.integer_types, description=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('description')
     def new(cls, ea, description, **extra):
@@ -4225,7 +4225,7 @@ def mark(ea):
     '''Return the mark at the specified address `ea`.'''
     _, res = marks.by_address(ea)
     return res
-@utils.multicase(description=basestring)
+@utils.multicase(description=six.string_types)
 @utils.string.decorate_arguments('description')
 def mark(description):
     '''Set the mark at the current address to the specified `description`.'''
@@ -4239,7 +4239,7 @@ def mark(ea, none):
         pass
     color(ea, None)
     return marks.remove(ea)
-@utils.multicase(ea=six.integer_types, description=basestring)
+@utils.multicase(ea=six.integer_types, description=six.string_types)
 @utils.string.decorate_arguments('description')
 def mark(ea, description):
     '''Sets the mark at address `ea` to the specified `description`.'''
@@ -4436,14 +4436,14 @@ class extra(object):
         cls.__delete__(ea, idaapi.E_NEXT)
         return res
 
-    @utils.multicase(ea=six.integer_types, string=basestring)
+    @utils.multicase(ea=six.integer_types, string=six.string_types)
     @classmethod
     def __set_prefix__(cls, ea, string):
         '''Set the prefixed comment at address `ea` to the specified `string`.'''
         res, ok = cls.__delete_prefix__(ea), cls.__set__(ea, string, idaapi.E_PREV)
         ok = cls.__set__(ea, string, idaapi.E_PREV)
         return res
-    @utils.multicase(ea=six.integer_types, string=basestring)
+    @utils.multicase(ea=six.integer_types, string=six.string_types)
     @classmethod
     def __set_suffix__(cls, ea, string):
         '''Set the suffixed comment at address `ea` to the specified `string`.'''
@@ -4470,12 +4470,12 @@ class extra(object):
     def __delete_suffix__(cls):
         '''Delete the suffixed comment at the current address.'''
         return cls.__delete_suffix__(ui.current.address())
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     def __set_prefix__(cls, string):
         '''Set the prefixed comment at the current address to the specified `string`.'''
         return cls.__set_prefix__(ui.current.address(), string)
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     def __set_suffix__(cls, string):
         '''Set the suffixed comment at the current address to the specified `string`.'''
@@ -4486,7 +4486,7 @@ class extra(object):
     def prefix(cls):
         '''Return the prefixed comment at the current address.'''
         return cls.__get_prefix__(ui.current.address())
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     def prefix(cls, string):
         '''Set the prefixed comment at the current address to the specified `string`.'''
@@ -4501,7 +4501,7 @@ class extra(object):
     def prefix(cls, ea):
         '''Return the prefixed comment at address `ea`.'''
         return cls.__get_prefix__(ea)
-    @utils.multicase(ea=six.integer_types, string=basestring)
+    @utils.multicase(ea=six.integer_types, string=six.string_types)
     @classmethod
     def prefix(cls, ea, string):
         '''Set the prefixed comment at address `ea` to the specified `string`.'''
@@ -4517,7 +4517,7 @@ class extra(object):
     def suffix(cls):
         '''Return the suffixed comment at the current address.'''
         return cls.__get_suffix__(ui.current.address())
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @classmethod
     def suffix(cls, string):
         '''Set the suffixed comment at the current address to the specified `string`.'''
@@ -4532,7 +4532,7 @@ class extra(object):
     def suffix(cls, ea):
         '''Return the suffixed comment at address `ea`.'''
         return cls.__get_suffix__(ea)
-    @utils.multicase(ea=six.integer_types, string=basestring)
+    @utils.multicase(ea=six.integer_types, string=six.string_types)
     @classmethod
     def suffix(cls, ea, string):
         '''Set the suffixed comment at address `ea` to the specified `string`.'''
@@ -4625,12 +4625,12 @@ class set(object):
 
     """
 
-    @utils.multicase(info=(basestring, idaapi.tinfo_t))
+    @utils.multicase(info=(six.string_types, idaapi.tinfo_t))
     @classmethod
     def info(cls, info):
         '''Set the typeinfo at the current address to `info`.'''
         return cls.info(ui.current.address(), info)
-    @utils.multicase(ea=six.integer_types, info=(basestring, idaapi.tinfo_t))
+    @utils.multicase(ea=six.integer_types, info=(six.string_types, idaapi.tinfo_t))
     @classmethod
     def info(cls, ea, info):
         '''Set the typeinfo at the address `ea` to `info`.'''

--- a/base/enumeration.py
+++ b/base/enumeration.py
@@ -89,7 +89,7 @@ byindex = utils.alias(by_index)
 def by(index):
     '''Return the identifier for the enumeration at the specified `index`.'''
     return index if interface.node.is_identifier(index) else by_index(index)
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def by(name):
     '''Return the identifier for the enumeration with the specified `name`.'''
@@ -110,7 +110,7 @@ def by(**type):
         raise E.SearchResultsError(u"{:s}.search({:s}) : Found 0 matching results.".format(__name__, searchstring))
     return res
 
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def search(string):
     '''Return the identifier of the first enumeration that matches the glob `string`.'''
@@ -153,7 +153,7 @@ def name(enum):
     eid = by(enum)
     res = idaapi.get_enum_name(eid)
     return utils.string.of(res)
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def name(enum, name):
     '''Rename the enumeration `enum` to the string `name`.'''
@@ -169,7 +169,7 @@ def comment(enum, **repeatable):
     eid = by(enum)
     res = idaapi.get_enum_cmt(eid, repeatable.get('repeatable', True))
     return utils.string.of(res)
-@utils.multicase(comment=basestring)
+@utils.multicase(comment=six.string_types)
 @utils.string.decorate_arguments('comment')
 def comment(enum, comment, **repeatable):
     """Set the comment for the enumeration `enum` to `comment`.
@@ -239,7 +239,7 @@ def iterate(**type):
         res = builtins.list(__matcher__.match(key, value, res))
     for item in res: yield item
 
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def list(string):
     '''List any enumerations that match the glob in `string`.'''
@@ -384,7 +384,7 @@ class members(object):
     def by(cls, enum, n):
         '''Return the member belonging to `enum` identified by its index or id in `n`.'''
         return cls.by_identifier(enum, n) if interface.node.is_identifier(n) else cls.by_index(enum, n)
-    @utils.multicase(member=basestring)
+    @utils.multicase(member=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('member')
     def by(cls, enum, member):
@@ -489,14 +489,14 @@ class member(object):
         eid = by(enum)
         mid = members.by(eid, member)
         return cls.name(mid)
-    @utils.multicase(mid=six.integer_types, name=(basestring, tuple))
+    @utils.multicase(mid=six.integer_types, name=(six.string_types, tuple))
     @classmethod
     @utils.string.decorate_arguments('name')
     def name(cls, mid, name):
         '''Rename the enumeration member `mid` to `name`.'''
         res = interface.tuplename(*name) if isinstance(name, tuple) else name
         return idaapi.set_enum_member_name(mid, utils.string.to(res))
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('name', 'suffix')
     def name(cls, enum, member, name, *suffix):
@@ -524,7 +524,7 @@ class member(object):
         eid = by(enum)
         mid = members.by(eid, member)
         return cls.comment(mid, **repeatable)
-    @utils.multicase(mid=six.integer_types, comment=basestring)
+    @utils.multicase(mid=six.integer_types, comment=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('comment')
     def comment(cls, mid, comment, **repeatable):
@@ -536,7 +536,7 @@ class member(object):
             raise E.MemberNotFoundError(u"{:s}.comment({:#x}, {!r}) : Unable to locate member by the specified identifier.".format('.'.join([__name__, cls.__name__]), mid, comment))
         res = utils.string.to(comment)
         return idaapi.set_enum_member_cmt(mid, res, repeatable.get('repeatable', True))
-    @utils.multicase(comment=basestring)
+    @utils.multicase(comment=six.string_types)
     @classmethod
     @utils.string.decorate_arguments('comment')
     def comment(cls, enum, member, comment, **repeatable):

--- a/base/function.py
+++ b/base/function.py
@@ -116,7 +116,7 @@ def comment(string, **repeatable):
     '''Set the comment for the current function to `string`.'''
     fn = ui.current.function()
     return comment(fn, string, **repeatable)
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def comment(none, **repeatable):
     '''Remove the comment for the current function.'''
     fn = ui.current.function()
@@ -134,7 +134,7 @@ def comment(func, string, **repeatable):
     if not ok:
         raise E.DisassemblerError(u"{:s}.comment({:#x}, \"{:s}\"{:s}) : Unable to call `idaapi.set_func_cmt({:#x}, {!r}, {!s})`.".format(__name__, ea, utils.string.escape(string, '"'), u", {:s}".format(utils.string.kwargs(repeatable)) if repeatable else '', ea, utils.string.to(string), repeatable.get('repeatable', True)))
     return res
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def comment(func, none, **repeatable):
     """Remove the comment for the function `func`.
 
@@ -177,7 +177,7 @@ def name(func):
     return internal.declaration.demangle(res) if internal.declaration.mangledQ(res) else res
     #return internal.declaration.extract.fullname(internal.declaration.demangle(res)) if internal.declaration.mangledQ(res) else res
     #return internal.declaration.extract.name(internal.declaration.demangle(res)) if internal.declaration.mangledQ(res) else res
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def name(none, **flags):
     '''Remove the custom-name from the current function.'''
     # we use ui.current.address() instead of ui.current.function()
@@ -189,7 +189,7 @@ def name(none, **flags):
 def name(string, *suffix, **flags):
     '''Set the name of the current function to `string`.'''
     return name(ui.current.address(), string, *suffix, **flags)
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def name(func, none, **flags):
     '''Remove the custom-name from the function `func`.'''
     return name(func, none or '', **flags)
@@ -272,7 +272,7 @@ def color(func):
     fn = by(func)
     b, r = (fn.color&0xff0000)>>16, fn.color&0x0000ff
     return None if fn.color == 0xffffffff else (r<<16) | (fn.color&0x00ff00) | b
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def color(func, none):
     '''Remove the color for the function `func`.'''
     fn = by(func)
@@ -285,7 +285,7 @@ def color(func, rgb):
     fn = by(func)
     fn.color = (b<<16) | (rgb&0x00ff00) | r
     return bool(idaapi.update_func(fn))
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def color(none):
     '''Remove the color for the current function.'''
     return color(ui.current.function(), None)
@@ -1115,7 +1115,7 @@ class block(object):
     def color(cls):
         '''Returns the color of the basic block at the current address.'''
         return cls.color(ui.current.address())
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     @classmethod
     def color(cls, none):
         '''Removes the color of the basic block at the current address.'''
@@ -1145,7 +1145,7 @@ class block(object):
         '''Returns the color of the basic block identified by `bounds`.'''
         bb = cls.at(bounds)
         return cls.color(bb)
-    @utils.multicase(ea=six.integer_types, none=types.NoneType)
+    @utils.multicase(ea=six.integer_types, none=None.__class__)
     @classmethod
     def color(cls, ea, none):
         '''Removes the color of the basic block at the address `ea`.'''
@@ -1160,13 +1160,13 @@ class block(object):
             database.color(ea, None)
             # internal.netnode.alt.remove(ea, 0x14)
         return res
-    @utils.multicase(bounds=builtins.tuple, none=types.NoneType)
+    @utils.multicase(bounds=builtins.tuple, none=None.__class__)
     @classmethod
     def color(cls, bounds, none):
         '''Removes the color of the basic block identified by `bounds`.'''
         bb = cls.at(bounds)
         return cls.color(bb, None)
-    @utils.multicase(bb=idaapi.BasicBlock, none=types.NoneType)
+    @utils.multicase(bb=idaapi.BasicBlock, none=None.__class__)
     @classmethod
     def color(cls, bb, none):
         '''Removes the color of the basic block `bb`.'''
@@ -1819,12 +1819,12 @@ def tag(func, key, value):
 
     # return what we fetched from the dict
     return res
-@utils.multicase(key=six.string_types, none=types.NoneType)
+@utils.multicase(key=six.string_types, none=None.__class__)
 @utils.string.decorate_arguments('key')
 def tag(key, none):
     '''Removes the tag identified by `key` for the current function.'''
     return tag(ui.current.address(), key, None)
-@utils.multicase(key=six.string_types, none=types.NoneType)
+@utils.multicase(key=six.string_types, none=None.__class__)
 @utils.string.decorate_arguments('key')
 def tag(func, key, none):
     '''Removes the tag identified by `key` from the function `func`.'''
@@ -2031,7 +2031,7 @@ class type(object):
     def __new__(cls, info):
         '''Apply the typeinfo in `info` to the current function.'''
         return cls(ui.current.address(), info)
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     def __new__(cls, none):
         '''Remove the typeinfo for the current function.'''
         return cls(ui.current.address(), None)
@@ -2127,7 +2127,7 @@ class type(object):
 
         # Just return the type we applied to the user.
         return cls(ea)
-    @utils.multicase(none=types.NoneType)
+    @utils.multicase(none=None.__class__)
     def __new__(cls, func, none):
         '''Remove the typeinfo for the function `func`.'''
         fn = by(func)

--- a/base/function.py
+++ b/base/function.py
@@ -75,7 +75,7 @@ def by(func):
 def by(ea):
     '''Return the function at the address `ea`.'''
     return by_address(ea)
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def by(name):
     '''Return the function with the specified `name`.'''
@@ -110,7 +110,7 @@ def comment(func, **repeatable):
     fn = by(func)
     res = idaapi.get_func_cmt(fn, repeatable.get('repeatable', True))
     return utils.string.of(res)
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def comment(string, **repeatable):
     '''Set the comment for the current function to `string`.'''
@@ -121,7 +121,7 @@ def comment(none, **repeatable):
     '''Remove the comment for the current function.'''
     fn = ui.current.function()
     return comment(fn, none or '', **repeatable)
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def comment(func, string, **repeatable):
     """Set the comment for the function `func` to `string`.
@@ -184,7 +184,7 @@ def name(none, **flags):
     # in case the user might be hovering over an import table
     # function and wanting to rename that instead.
     return name(ui.current.address(), none or '', **flags)
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string', 'suffix')
 def name(string, *suffix, **flags):
     '''Set the name of the current function to `string`.'''
@@ -193,7 +193,7 @@ def name(string, *suffix, **flags):
 def name(func, none, **flags):
     '''Remove the custom-name from the function `func`.'''
     return name(func, none or '', **flags)
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string', 'suffix')
 def name(func, string, *suffix, **flags):
     """Set the name of the function `func` to `string`.
@@ -437,12 +437,12 @@ class chunks(object):
             continue
         raise E.AddressNotFoundError(u"{:s}.at({:#x}, {:#x}) : Unable to locate chunk for address {:#x} in function {:#x}.".format('.'.join([__name__, cls.__name__]), interface.range.start(fn), ea, ea, interface.range.start(fn)))
 
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, reg, *regs, **modifiers):
         '''Yield each `(address, opnum, state)` within the current function that uses `reg` or any one of the registers in `regs`.'''
         return cls.register(ui.current.function(), reg, *regs, **modifiers)
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, func, reg, *regs, **modifiers):
         """Yield each `(address, opnum, state)` within the function `func` that uses `reg` or any one of the registers in `regs`.
@@ -500,12 +500,12 @@ class chunk(object):
             yield ea
         return
 
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, reg, *regs, **modifiers):
         '''Yield each `(address, opnum, state)` within the function chunk containing the current address which uses `reg` or any one of the registers in `regs`.'''
         return cls.register(ui.current.function(), reg, *regs, **modifiers)
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, ea, reg, *regs, **modifiers):
         """Yield each `(address, opnum, state)` within the function chunk containing the address `ea` which uses `reg` or any one of the registers in `regs`.
@@ -1317,24 +1317,24 @@ class block(object):
         left, right = interface.range.unpack(bb)
         return database.address.iterate(left, database.address.prev(right))
 
-    @utils.multicase(reg=(basestring, interface.register_t))
+    @utils.multicase(reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, reg, *regs, **modifiers):
         '''Yield each `(address, opnum, state)` within the current block that uses `reg` or any one of the registers in `regs`.'''
         return cls.register(ui.current.address(), reg, *regs, **modifiers)
-    @utils.multicase(ea=six.integer_types, reg=(basestring, interface.register_t))
+    @utils.multicase(ea=six.integer_types, reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, ea, reg, *regs, **modifiers):
         '''Yield each `(address, opnum, state)` within the block containing `ea` that uses `reg` or any one of the registers in `regs`.'''
         bb = cls.at(ea)
         return cls.register(bb, reg, *regs, **modifiers)
-    @utils.multicase(bounds=builtins.tuple, reg=(basestring, interface.register_t))
+    @utils.multicase(bounds=builtins.tuple, reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, bounds, reg, *regs, **modifiers):
         '''Yield each `(address, opnum, state)` within the block identified by `bounds` that uses `reg` or any one of the registers in `regs`.'''
         bb = cls.at(bounds)
         return cls.register(bb, reg, *regs, **modifiers)
-    @utils.multicase(bb=idaapi.BasicBlock, reg=(basestring, interface.register_t))
+    @utils.multicase(bb=idaapi.BasicBlock, reg=(six.string_types, interface.register_t))
     @classmethod
     def register(cls, bb, reg, *regs, **modifiers):
         """Yield each `(address, opnum, state)` within the block `bb` that uses `reg` or any one of the registers in `regs`.
@@ -1688,17 +1688,17 @@ arguments = args = frame.args
 def tag():
     '''Returns all the tags defined for the current function.'''
     return tag(ui.current.address())
-@utils.multicase(key=basestring)
+@utils.multicase(key=six.string_types)
 @utils.string.decorate_arguments('key')
 def tag(key):
     '''Returns the value of the tag identified by `key` for the current function.'''
     return tag(ui.current.address(), key)
-@utils.multicase(key=basestring)
+@utils.multicase(key=six.string_types)
 @utils.string.decorate_arguments('key', 'value')
 def tag(key, value):
     '''Sets the value for the tag `key` to `value` for the current function.'''
     return tag(ui.current.address(), key, value)
-@utils.multicase(key=basestring)
+@utils.multicase(key=six.string_types)
 @utils.string.decorate_arguments('key')
 def tag(func, key):
     '''Returns the value of the tag identified by `key` for the function `func`.'''
@@ -1760,7 +1760,7 @@ def tag(func):
 
     # ..and now hand it off.
     return res
-@utils.multicase(key=basestring)
+@utils.multicase(key=six.string_types)
 @utils.string.decorate_arguments('key', 'value')
 def tag(func, key, value):
     '''Sets the value for the tag `key` to `value` for the function `func`.'''
@@ -1819,12 +1819,12 @@ def tag(func, key, value):
 
     # return what we fetched from the dict
     return res
-@utils.multicase(key=basestring, none=types.NoneType)
+@utils.multicase(key=six.string_types, none=types.NoneType)
 @utils.string.decorate_arguments('key')
 def tag(key, none):
     '''Removes the tag identified by `key` for the current function.'''
     return tag(ui.current.address(), key, None)
-@utils.multicase(key=basestring, none=types.NoneType)
+@utils.multicase(key=six.string_types, none=types.NoneType)
 @utils.string.decorate_arguments('key')
 def tag(func, key, none):
     '''Removes the tag identified by `key` from the function `func`.'''
@@ -1898,14 +1898,14 @@ def tags(func):
 def select(**boolean):
     '''Query the contents of the current function for any tags specified by `boolean`'''
     return select(ui.current.function(), **boolean)
-@utils.multicase(tag=basestring)
+@utils.multicase(tag=six.string_types)
 @utils.string.decorate_arguments('tag', 'And', 'Or')
 def select(tag, *Or, **boolean):
     '''Query the contents of the current function for the specified `tag` and any others specified as `Or`.'''
     res = {tag} | {item for item in Or}
     boolean['Or'] = {item for item in boolean.get('Or', [])} | res
     return select(ui.current.function(), **boolean)
-@utils.multicase(tag=basestring)
+@utils.multicase(tag=six.string_types)
 @utils.string.decorate_arguments('tag', 'And', 'Or')
 def select(func, tag, *Or, **boolean):
     '''Query the contents of the function `func` for the specified `tag` and any others specified as `Or`.'''
@@ -2027,7 +2027,7 @@ class type(object):
     def __new__(cls):
         '''Return the typeinfo for the current function as a ``idaapi.tinfo_t``.'''
         return cls(ui.current.address())
-    @utils.multicase(info=(basestring, idaapi.tinfo_t))
+    @utils.multicase(info=(six.string_types, idaapi.tinfo_t))
     def __new__(cls, info):
         '''Apply the typeinfo in `info` to the current function.'''
         return cls(ui.current.address(), info)
@@ -2076,7 +2076,7 @@ class type(object):
 
         # Recurse back into ourselves in order to call idaapi.apply_cdecl
         return cls(ea, tinfo_s)
-    @utils.multicase(info=basestring)
+    @utils.multicase(info=six.string_types)
     def __new__(cls, func, info):
         '''Parse the typeinfo string in `info` to an ``idaapi.tinfo_t`` and apply it to the function `func`.'''
         til = idaapi.cvar.idati if idaapi.__version__ < 7.0 else idaapi.get_idati()

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -349,11 +349,11 @@ def ops_register(ea, **modifiers):
     iterops = interface.regmatch.modifier(**modifiers)
     fregisterQ = utils.fcompose(op, utils.fcondition(utils.finstance(interface.symbol_t))(utils.fcompose(utils.fattribute('symbols'), functools.partial(map, utils.finstance(interface.register_t)), any), utils.fconstant(False)))
     return tuple(filter(functools.partial(fregisterQ, ea), iterops(ea)))
-@utils.multicase(reg=(basestring, interface.register_t))
+@utils.multicase(reg=(six.string_types, interface.register_t))
 def ops_register(reg, *regs, **modifiers):
     '''Yields the index of each operand in the instruction at the current address that uses `reg` or any one of the registers in `regs`.'''
     return ops_register(ui.current.address(), reg, *regs, **modifiers)
-@utils.multicase(reg=(basestring, interface.register_t))
+@utils.multicase(reg=(six.string_types, interface.register_t))
 def ops_register(ea, reg, *regs, **modifiers):
     """Yields the index of each operand in the instruction at address `ea` that uses `reg` or any one of the registers in `regs`.
 
@@ -918,7 +918,7 @@ def op_structure(ea, opnum, path, **delta):
     if len(path) == 0:
         raise E.InvalidParameterError(u"{:s}.op_structure({:#x}, {:d}, {!r}, delta={:d}) : No structure members were specified.".format(__name__, ea, opnum, path, delta.get('delta', 0)))
 
-    if any(not isinstance(m, (structure.structure_t, structure.member_t, basestring) + six.integer_types) for m in path):
+    if any(not isinstance(m, (structure.structure_t, structure.member_t, six.string_types, six.integer_types)) for m in path):
         raise E.InvalidParameterError(u"{:s}.op_structure({:#x}, {:d}, {!r}, delta={:d}) : A member of an invalid type was specified.".format(__name__, ea, opnum, path, delta.get('delta', 0)))
 
     # ensure the path begins with a structure.structure_t
@@ -944,7 +944,7 @@ def op_structure(ea, opnum, path, **delta):
     # collect each member resolving them to an id
     moff, tids = 0, []
     for i, item in enumerate(path[1:]):
-        if isinstance(item, basestring):
+        if isinstance(item, six.string_types):
             m = idaapi.get_member_by_name(sptr, item)
         elif isinstance(item, structure.member_t):
             m = item.ptr
@@ -1022,12 +1022,12 @@ def op_enumeration(ea, opnum):
     # Grab the operand value and use it to return the member identifier for the enumeration
     res = op(ea, opnum)
     return idaapi.get_enum_member(E, res, -1, 0)
-@utils.multicase(opnum=six.integer_types, name=basestring)
+@utils.multicase(opnum=six.integer_types, name=six.string_types)
 @utils.string.decorate_arguments('name')
 def op_enumeration(opnum, name):
     '''Apply the enumeration `name` to operand `opnum` for the current instruction.'''
     return op_enumeration(ui.current.address(), opnum, enumeration.by(name))
-@utils.multicase(ea=six.integer_types, opnum=six.integer_types, name=basestring)
+@utils.multicase(ea=six.integer_types, opnum=six.integer_types, name=six.string_types)
 @utils.string.decorate_arguments('name')
 def op_enumeration(ea, opnum, name):
     '''Apply the enumeration `name` to operand `opnum` for the instruction at `ea`.'''

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -1601,7 +1601,7 @@ class operand_types:
         sf, dt = 2 ** (bits - 1), dtype_by_size(database.config.bits() // 8)
 
         inverted, regular = offset & (2 ** bits - 1) if offset & sf else -2 ** bits + offset, -2 ** bits + offset if offset & sf else offset & (sf - 1)
-        res = long(inverted) if interface.node.alt_opinverted(ea, op.n) else long(regular), None if base is None else architecture.by_indextype(base, dt), None if index is None else architecture.by_indextype(index, dt), scale
+        res = inverted if interface.node.alt_opinverted(ea, op.n) else regular, None if base is None else architecture.by_indextype(base, dt), None if index is None else architecture.by_indextype(index, dt), scale
         return intelops.OffsetBaseIndexScale(*res)
 
     @__optype__.define(idaapi.PLFM_ARM, idaapi.o_phrase)
@@ -1620,7 +1620,7 @@ class operand_types:
         '''Operand type decoder for returning a memory displacement on either the AArch32 or AArch64 architectures.'''
         global architecture
         Rn = architecture.by_index(op.reg)
-        return armops.immediatephrase(Rn, long(op.addr))
+        return armops.immediatephrase(Rn, op.addr)
 
     @__optype__.define(idaapi.PLFM_ARM, idaapi.o_mem)
     def memory(ea, op):
@@ -1639,7 +1639,7 @@ class operand_types:
         res = reduce(lambda agg, n: (agg*0x100)|n, six.iterbytes(res), 0)
         sf = bool(res & maxval>>1)
 
-        return armops.memory(long(addr), long(res-maxval) if sf else long(res))
+        return armops.memory(addr, res - maxval if sf else res)
 
     @__optype__.define(idaapi.PLFM_ARM, idaapi.o_idpspec0)
     def flex(ea, op):

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -1755,7 +1755,7 @@ class intelops:
         """
         _fields = ('segment', 'offset')
         _types = (
-            (types.NoneType, interface.register_t),
+            (None.__class__, interface.register_t),
             six.integer_types,
         )
 
@@ -1775,10 +1775,10 @@ class intelops:
         """
         _fields = ('segment', 'offset', 'base', 'index', 'scale')
         _types = (
-            (types.NoneType, interface.register_t),
+            (None.__class__, interface.register_t),
             six.integer_types,
-            (types.NoneType, interface.register_t),
-            (types.NoneType, interface.register_t),
+            (None.__class__, interface.register_t),
+            (None.__class__, interface.register_t),
             six.integer_types,
         )
 
@@ -1800,8 +1800,8 @@ class intelops:
         _fields = ('offset', 'base', 'index', 'scale')
         _types = (
             six.integer_types,
-            (types.NoneType, interface.register_t),
-            (types.NoneType, interface.register_t),
+            (None.__class__, interface.register_t),
+            (None.__class__, interface.register_t),
             six.integer_types,
         )
 

--- a/base/segment.py
+++ b/base/segment.py
@@ -79,7 +79,7 @@ def __iterate__(**type):
         iterable = builtins.list(__matcher__.match(key, value, iterable))
     for item in iterable: yield item
 
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def list(string):
     '''List all of the segments whose name matches the glob specified by `string`.'''
@@ -143,7 +143,7 @@ byaddress = utils.alias(by_address)
 def by(segment):
     '''Return a segment by its ``idaapi.segment_t``.'''
     return segment
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def by(name):
     '''Return the segment by its `name`.'''
@@ -175,7 +175,7 @@ def by(**type):
         raise E.SearchResultsError(u"{:s}.by({:s}) : Found 0 matching results.".format(__name__, searchstring))
     return res
 
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def search(name):
     '''Search through all the segments and return the first one matching the glob `name`.'''
@@ -387,7 +387,7 @@ def contains(address, ea):
     '''Returns true if the address `ea` is contained within the segment belonging to the specified `address`.'''
     seg = by_address(address)
     return contains(seg, ea)
-@utils.multicase(name=basestring, ea=six.integer_types)
+@utils.multicase(name=six.string_types, ea=six.integer_types)
 @utils.string.decorate_arguments('name')
 def contains(name, ea):
     '''Returns true if the address `ea` is contained within the segment with the specified `name`.'''

--- a/base/segment.py
+++ b/base/segment.py
@@ -351,11 +351,11 @@ def color(segment):
     seg = by(segment)
     b,r = (seg.color&0xff0000)>>16, seg.color&0x0000ff
     return None if seg.color == 0xffffffff else (r<<16)|(seg.color&0x00ff00)|b
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def color(none):
     '''Clear the color of the current segment.'''
     return color(ui.current.segment(), None)
-@utils.multicase(none=types.NoneType)
+@utils.multicase(none=None.__class__)
 def color(segment, none):
     '''Clear the color of the segment identified by `segment`.'''
     seg = by(segment)

--- a/base/structure.py
+++ b/base/structure.py
@@ -101,7 +101,7 @@ def __iterate__():
         yield __instance__(idaapi.get_struc_by_idx(res))
     return
 
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def iterate(string):
     '''Iterate through all of the structures in the database with a glob that matches `string`.'''
@@ -116,7 +116,7 @@ def iterate(**type):
         res = builtins.list(__matcher__.match(key, value, res))
     for item in res: yield item
 
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
 def list(string):
     '''List any structures that match the glob in `string`.'''
@@ -135,12 +135,12 @@ def list(**type):
         six.print_(u"[{:{:d}d}] {:>{:d}s} {:<+#{:d}x} ({:d} members){:s}".format(idaapi.get_struc_idx(st.id), maxindex, st.name, maxname, st.size, maxsize, len(st.members), u" // {!s}".format(st.tag() if '\n' in st.comment else st.comment) if st.comment else ''))
     return
 
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def new(name):
     '''Returns a new structure `name`.'''
     return new(name, 0)
-@utils.multicase(name=basestring, offset=six.integer_types)
+@utils.multicase(name=six.string_types, offset=six.integer_types)
 @utils.string.decorate_arguments('name')
 def new(name, offset):
     '''Returns a new structure `name` using `offset` as its base offset.'''
@@ -156,7 +156,7 @@ def new(name, offset):
     # Create a new instance in the structure cache with the specified id
     return __instance__(id, offset=offset)
 
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def by(name, **options):
     '''Return a structure by its name.'''
@@ -183,7 +183,7 @@ def by(**type):
         raise E.SearchResultsError(u"{:s}.search({:s}) : Found 0 matching results.".format(__name__, searchstring))
     return res
 
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 def search(string):
     '''Search through all the structure names matching the glob `string`.'''
     return by(like=string)
@@ -529,13 +529,13 @@ class structure_t(object):
         res = {}
         builtins.map(res.update, (d1, d2) if repeatable else (d2, d1))
         return res
-    @utils.multicase(key=basestring)
+    @utils.multicase(key=six.string_types)
     @utils.string.decorate_arguments('key')
     def tag(self, key):
         '''Return the tag identified by `key` belonging to the structure.'''
         res = self.tag()
         return res[key]
-    @utils.multicase(key=basestring)
+    @utils.multicase(key=six.string_types)
     @utils.string.decorate_arguments('key', 'value')
     def tag(self, key, value):
         '''Set the tag identified by `key` to `value` for the structure.'''
@@ -543,7 +543,7 @@ class structure_t(object):
         repeatable, res, state[key] = True, state.get(key, None), value
         ok = idaapi.set_struc_cmt(self.id, utils.string.to(internal.comment.encode(state)), repeatable)
         return res
-    @utils.multicase(key=basestring, none=types.NoneType)
+    @utils.multicase(key=six.string_types, none=types.NoneType)
     @utils.string.decorate_arguments('key')
     def tag(self, key, none):
         '''Removes the tag specified by `key` from the structure.'''
@@ -664,7 +664,7 @@ def name(id):
 @utils.multicase(structure=structure_t)
 def name(structure):
     return name(structure.id)
-@utils.multicase(string=basestring)
+@utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string', 'suffix')
 def name(id, string, *suffix):
     '''Set the name of the structure identified by `id` to `string`.'''
@@ -682,7 +682,7 @@ def name(id, string, *suffix):
 
     # now we can set the name of the structure
     return idaapi.set_struc_name(id, ida_string)
-@utils.multicase(structure=structure_t, string=basestring)
+@utils.multicase(structure=structure_t, string=six.string_types)
 @utils.string.decorate_arguments('string', 'suffix')
 def name(structure, string, *suffix):
     '''Set the name of the specified `structure` to `string`.'''
@@ -700,7 +700,7 @@ def comment(id, **repeatable):
 def comment(structure, **repeatable):
     '''Return the comment for the specified `structure`.'''
     return comment(structure.id, **repeatable)
-@utils.multicase(structure=structure_t, cmt=basestring)
+@utils.multicase(structure=structure_t, cmt=six.string_types)
 @utils.string.decorate_arguments('cmt')
 def comment(structure, cmt, **repeatable):
     '''Set the comment to `cmt` for the specified `structure`.'''
@@ -709,7 +709,7 @@ def comment(structure, cmt, **repeatable):
 def comment(structure, none, **repeatable):
     '''Remove the comment from the specified `structure`.'''
     return comment(structure.id, none or '', **repeatable)
-@utils.multicase(id=six.integer_types, cmt=basestring)
+@utils.multicase(id=six.integer_types, cmt=six.string_types)
 @utils.string.decorate_arguments('cmt')
 def comment(id, cmt, **repeatable):
     """Set the comment of the structure identified by `id` to `cmt`.
@@ -841,7 +841,7 @@ def remove(structure):
     if not ok:
         raise E.StructureNotFoundError(u"{:s}.remove({!r}) : Unable to remove structure {:#x}.".format(__name__, structure, structure.id))
     return True
-@utils.multicase(name=basestring)
+@utils.multicase(name=six.string_types)
 @utils.string.decorate_arguments('name')
 def remove(name):
     '''Remove the structure with the specified `name`.'''
@@ -993,13 +993,13 @@ class members_t(object):
         for key, value in six.iteritems(type):
             res = builtins.list(self.__member_matcher.match(key, value, res))
         for item in res: yield item
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @utils.string.decorate_arguments('string')
     def iterate(self, string):
         '''Iterate through all of the members in the structure with a name that matches the glob in `string`.'''
         return self.iterate(like=string)
 
-    @utils.multicase(string=basestring)
+    @utils.multicase(string=six.string_types)
     @utils.string.decorate_arguments('string')
     def list(self, string):
         '''List any members that match the glob in `string`.'''
@@ -1038,7 +1038,7 @@ class members_t(object):
             cls = self.__class__
             raise E.SearchResultsError(u"{:s}({:#x}).members.by({:s}) : Found 0 matching results.".format('.'.join([__name__, cls.__name__]), self.parent.id, searchstring))
         return res
-    @utils.multicase(name=basestring)
+    @utils.multicase(name=six.string_types)
     @utils.string.decorate_arguments('name')
     def by(self, name):
         '''Return the member with the specified `name`.'''
@@ -1271,19 +1271,19 @@ class members_t(object):
         return self[index]
 
     # adding/removing members
-    @utils.multicase(name=(basestring, tuple))
+    @utils.multicase(name=(six.string_types, tuple))
     @utils.string.decorate_arguments('name')
     def add(self, name):
         '''Append the specified member `name` with the default type at the end of the structure.'''
         offset = self.parent.size + self.baseoffset
         return self.add(name, int, offset)
-    @utils.multicase(name=(basestring, tuple))
+    @utils.multicase(name=(six.string_types, tuple))
     @utils.string.decorate_arguments('name')
     def add(self, name, type):
         '''Append the specified member `name` with the given `type` at the end of the structure.'''
         offset = self.parent.size + self.baseoffset
         return self.add(name, type, offset)
-    @utils.multicase(name=(basestring, tuple), offset=six.integer_types)
+    @utils.multicase(name=(six.string_types, tuple), offset=six.integer_types)
     @utils.string.decorate_arguments('name')
     def add(self, name, type, offset):
         """Add a member at `offset` with the given `name` and `type`.
@@ -1636,13 +1636,13 @@ class member_t(object):
         res = {}
         builtins.map(res.update, (d1, d2) if repeatable else (d2, d1))
         return res
-    @utils.multicase(key=basestring)
+    @utils.multicase(key=six.string_types)
     @utils.string.decorate_arguments('key')
     def tag(self, key):
         '''Return the tag identified by `key` belonging to the member.'''
         res = self.tag()
         return res[key]
-    @utils.multicase(key=basestring)
+    @utils.multicase(key=six.string_types)
     @utils.string.decorate_arguments('key', 'value')
     def tag(self, key, value):
         '''Set the tag identified by `key` to `value` for the member.'''
@@ -1650,7 +1650,7 @@ class member_t(object):
         repeatable, res, state[key] = True, state.get(key, None), value
         ok = idaapi.set_member_cmt(self.ptr, utils.string.to(internal.comment.encode(state)), repeatable)
         return res
-    @utils.multicase(key=basestring, none=types.NoneType)
+    @utils.multicase(key=six.string_types, none=types.NoneType)
     @utils.string.decorate_arguments('key')
     def tag(self, key, none):
         '''Removes the tag specified by `key` from the member.'''

--- a/base/structure.py
+++ b/base/structure.py
@@ -543,7 +543,7 @@ class structure_t(object):
         repeatable, res, state[key] = True, state.get(key, None), value
         ok = idaapi.set_struc_cmt(self.id, utils.string.to(internal.comment.encode(state)), repeatable)
         return res
-    @utils.multicase(key=six.string_types, none=types.NoneType)
+    @utils.multicase(key=six.string_types, none=None.__class__)
     @utils.string.decorate_arguments('key')
     def tag(self, key, none):
         '''Removes the tag specified by `key` from the structure.'''
@@ -705,7 +705,7 @@ def comment(structure, **repeatable):
 def comment(structure, cmt, **repeatable):
     '''Set the comment to `cmt` for the specified `structure`.'''
     return comment(structure.id, cmt, **repeatable)
-@utils.multicase(structure=structure_t, none=types.NoneType)
+@utils.multicase(structure=structure_t, none=None.__class__)
 def comment(structure, none, **repeatable):
     '''Remove the comment from the specified `structure`.'''
     return comment(structure.id, none or '', **repeatable)
@@ -718,7 +718,7 @@ def comment(id, cmt, **repeatable):
     """
     res = utils.string.to(cmt)
     return idaapi.set_struc_cmt(id, res, repeatable.get('repeatable', True))
-@utils.multicase(id=six.integer_types, none=types.NoneType)
+@utils.multicase(id=six.integer_types, none=None.__class__)
 def comment(id, none, **repeatable):
     '''Remove the comment from the structure identified by `id`.'''
     return comment(id, none or '', **repeatable)
@@ -1650,7 +1650,7 @@ class member_t(object):
         repeatable, res, state[key] = True, state.get(key, None), value
         ok = idaapi.set_member_cmt(self.ptr, utils.string.to(internal.comment.encode(state)), repeatable)
         return res
-    @utils.multicase(key=six.string_types, none=types.NoneType)
+    @utils.multicase(key=six.string_types, none=None.__class__)
     @utils.string.decorate_arguments('key')
     def tag(self, key, none):
         '''Removes the tag specified by `key` from the member.'''

--- a/custom/tags.py
+++ b/custom/tags.py
@@ -288,7 +288,7 @@ class apply(object):
                 if not name.startswith(' '): break
 
                 # if type is a string, then treat it as a structure so we can calculate a size
-                if isinstance(type, basestring):
+                if isinstance(type, six.string_types):
                     try:
                         st = struc.by(type)
                     except internal.exceptions.StructureNotFoundError:
@@ -357,7 +357,7 @@ class apply(object):
             member.comment = internal.comment.encode(state)
 
             # if the type is a string, then figure out which structure to use
-            if isinstance(type, basestring):
+            if isinstance(type, six.string_types):
                 try:
                     member.type = struc.by(type)
                 except internal.exceptions.StructureNotFoundError:

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -51,7 +51,7 @@ class ask(object):
     def __new__(cls, **default):
         '''Request the user choose from the options "yes", "no", or "cancel".'''
         return cls(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     def __new__(cls, message, **default):
         '''Request the user choose from the options "yes", "no", or "cancel" using the specified `message` as the prompt.'''
         return cls.yn(message, **default)
@@ -61,7 +61,7 @@ class ask(object):
     def yn(cls, **default):
         '''Request the user choose from the options "yes", "no", or "cancel".'''
         return cls.yn(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     @classmethod
     @internal.utils.string.decorate_arguments('message')
     def yn(cls, message, **default):
@@ -88,7 +88,7 @@ class ask(object):
     def address(cls, **default):
         '''Request the user provide an address.'''
         return cls.address(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     @classmethod
     @internal.utils.string.decorate_arguments('message')
     def address(cls, message, **default):
@@ -127,7 +127,7 @@ class ask(object):
     def integer(cls, **default):
         '''Request the user provide an integer.'''
         return cls.integer(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     @classmethod
     @internal.utils.string.decorate_arguments('message')
     def integer(cls, message, **default):
@@ -149,7 +149,7 @@ class ask(object):
     def segment(cls, **default):
         '''Request the user provide a segment.'''
         return cls.segment(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     @classmethod
     @internal.utils.string.decorate_arguments('message')
     def segment(cls, message, **default):
@@ -175,7 +175,7 @@ class ask(object):
     def string(cls, **default):
         '''Request the user provide a string.'''
         return cls.string(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     @classmethod
     @internal.utils.string.decorate_arguments('message', 'default', 'text', 'string')
     def string(cls, message, **default):
@@ -194,7 +194,7 @@ class ask(object):
     def note(cls, **default):
         '''Request the user provide a multi-lined string.'''
         return cls.note(u'', **default)
-    @internal.utils.multicase(message=basestring)
+    @internal.utils.multicase(message=six.string_types)
     @classmethod
     @internal.utils.string.decorate_arguments('message', 'default', 'text', 'string')
     def note(cls, message, **default):


### PR DESCRIPTION
Python3 removes types from the `types` module like `types.NoneType` and `types.TypeType`. This PR replaces `types.NoneType` with `None.__class__`, and `types.TypeType` with `builtins.type`. The `basestring` base class is also removed as there is now only one `str` class to rule them all. In order to retain Python2 compatibility, this class is replaced with `six.string_types`.

This PR is the third part of the fix for issue #76, and is dependant on PR #81. 