### PR TITLE
Replaced a number of `six` wrappers with builtins and comprehensions that are compatible with Python3.

### DIFF
--- a/base/_declaration.py
+++ b/base/_declaration.py
@@ -23,7 +23,7 @@ def function(ea):
 def arguments(ea):
     '''Returns an array of all of the arguments within the prototype of the function at `ea`.'''
     decl = function(ea)
-    args = decl[ decl.index('(')+1: decl.rindex(')') ]
+    args = decl[ decl.index('(') + 1 : decl.rindex(')') ]
     return [ arg.strip() for arg in args.split(',')]
 
 def size(string):
@@ -56,7 +56,7 @@ def demangle(string):
 
 def mangledQ(string):
     '''Return true if the provided `string` has been mangled.'''
-    return any(string.startswith(n) for n in ('?', '__'))
+    return any(string.startswith(item) for item in ['?', '__'])
 
 @internal.utils.string.decorate_arguments('info')
 def parse(info):
@@ -123,7 +123,7 @@ def unmangle_name(name):
         items = items[:]
 
     # Strip out any backticked components, operators, and other weirdness.
-    foperatorQ = lambda s: s.startswith('operator') and any(s.endswith(invalid) for invalid in _string.punctuation)
+    foperatorQ = lambda string: string.startswith('operator') and any(string.endswith(invalid) for invalid in _string.punctuation)
     joined = ' '.join(items)
     if '::' in joined:
         components = joined.split('::')
@@ -147,12 +147,12 @@ def unmangle_arguments(ea):
     parameters = extract.arguments("{!s}".format(idaapi.idc_get_type(ea))) or extract.arguments("{!s}".format(info))
     param_s = parameters.lstrip('(').rstrip(')')
 
-    index, indices, iterable = 0, [], iter(enumerate(param_s))
+    index, indices, iterable = 0, [], ((idx, item) for idx, item in enumerate(param_s))
     for argi in range(info.get_nargs()):
         arg = info.get_nth_arg(argi)
         arg_s = "{!s}".format(arg)
 
-        index, ch = next(iterable, (1+index,','))
+        index, ch = next(iterable, (1 + index, ','))
         while ch in ' ':
             index, ch = next(iterable)
 
@@ -163,7 +163,7 @@ def unmangle_arguments(ea):
 
             count = 0
             while ch != ',' or count > 0:
-                index, ch = next(iterable, (1+index, ','))
+                index, ch = next(iterable, (1 + index, ','))
                 if ch in '()':
                     count += -1 if ch in ')' else +1
                 continue
@@ -207,14 +207,14 @@ class extract:
 
     @staticmethod
     def convention(string):
-        types = set(('__cdecl', '__stdcall', '__thiscall', '__fastcall'))
+        types = {'__cdecl', '__stdcall', '__thiscall', '__fastcall'}
         res = string.split(' ')
         return res[0]
 
     @staticmethod
     def fullname(string):
         decl = extract.declaration(string)
-        return decl[:decl.find('(')].split(' ', 3)[-1] if any(n in decl for n in ('(', ' ')) else decl
+        return decl[:decl.find('(')].split(' ', 3)[-1] if any(item in decl for item in ['(', ' ']) else decl
 
     @staticmethod
     def name(string):

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -861,12 +861,12 @@ class node(object):
                 raise internal.exceptions.UnsupportedCapability(u"{:s}.sup_functype(\"{!s}\") : Calling conventions that return an {!s}({:d}) where the flags ({:#x} are not equal to {:#x} are currently not supported. The flags and the modification flags ({:#x}) were extracted from the byte {:#{:d}x}.".format('.'.join([__name__, node.__name__]), sup.encode('hex'), lookup[base], base, flags, 0x30, mods, item, 2 + 2))
             raise internal.exceptions.UnsupportedCapability(u"{:s}.sup_functype(\"{!s}\") : Calling conventions that return an {!s}({:d}) are currently not supported. The flags ({:#x}) and the modification flags ({:#x}) were extracted from the byte {:#{:d}x}.".format('.'.join([__name__, node.__name__]), sup.encode('hex'), lookup[base], base, flags, mods, item, 2 + 2))
 
-        # append the return type
-        res.append(data)
+        # append the return type as some bytes
+        res.append(bytes(data))
 
         # append the number of arguments
         by = builtins.next(iterable)
-        res.append(bytearray([by]))
+        res.append(by)
 
         # Everything else in the iterable is an array of type_t as found in "Type flags" in the SDK docs.
         ''.join(iterable)

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -190,46 +190,46 @@ class utils(object):
 
     @classmethod
     def falt(cls, node):
-        for res in cls.valfiter(node, netnode.altfirst, netnode.altlast, netnode.altnext, netnode.altval):
-            yield res
+        for item in cls.valfiter(node, netnode.altfirst, netnode.altlast, netnode.altnext, netnode.altval):
+            yield item
         return
     @classmethod
     def ralt(cls, node):
-        for res in cls.valriter(node, netnode.altfirst, netnode.altprev, netnode.altnext, netnode.altval):
-            yield res
+        for item in cls.valriter(node, netnode.altfirst, netnode.altprev, netnode.altnext, netnode.altval):
+            yield item
         return
 
     @classmethod
     def fsup(cls, node):
-        for res in cls.valfiter(node, netnode.supfirst, netnode.suplast, netnode.supnext, netnode.supval):
-            yield res
+        for item in cls.valfiter(node, netnode.supfirst, netnode.suplast, netnode.supnext, netnode.supval):
+            yield item
         return
     @classmethod
     def rsup(cls, node):
-        for res in cls.valriter(node, netnode.supfirst, netnode.supprev, netnode.supnext, netnode.supval):
-            yield res
+        for item in cls.valriter(node, netnode.supfirst, netnode.supprev, netnode.supnext, netnode.supval):
+            yield item
         return
 
     @classmethod
     def fhash(cls, node):
-        for res in cls.hfiter(node, netnode.hashfirst, netnode.hashlast, netnode.hashnext, netnode.hashval):
-            yield res
+        for item in cls.hfiter(node, netnode.hashfirst, netnode.hashlast, netnode.hashnext, netnode.hashval):
+            yield item
         return
     @classmethod
     def rhash(cls, node):
-        for res in cls.hriter(node, netnode.hashfirst, netnode.hashprev, netnode.hashnext, netnode.hashval):
-            yield res
+        for item in cls.hriter(node, netnode.hashfirst, netnode.hashprev, netnode.hashnext, netnode.hashval):
+            yield item
         return
 
     @classmethod
     def fchar(cls, node):
-        for res in cls.valfiter(node, netnode.charfirst, netnode.charlast, netnode.charnext, netnode.charval):
-            yield res
+        for item in cls.valfiter(node, netnode.charfirst, netnode.charlast, netnode.charnext, netnode.charval):
+            yield item
         return
     @classmethod
     def rchar(cls, node):
-        for res in cls.valriter(node, netnode.charfirst, netnode.charprev, netnode.charnext, netnode.charval):
-            yield res
+        for item in cls.valriter(node, netnode.charfirst, netnode.charprev, netnode.charnext, netnode.charval):
+            yield item
         return
 
 def new(name):
@@ -443,9 +443,9 @@ class sup(object):
     @classmethod
     def repr(cls, nodeidx):
         res = []
-        for i, idx in enumerate(cls.fiter(nodeidx)):
-            value = cls.get(nodeidx, idx)
-            res.append("[{:d}] {:x} : {!r}".format(i, idx, value))
+        for idx, item in enumerate(cls.fiter(nodeidx)):
+            value = cls.get(nodeidx, item)
+            res.append("[{:d}] {:x} : {!r}".format(idx, item, value))
         if not res:
             raise internal.exceptions.MissingTypeOrAttribute(u"{:s}.repr({:#x}) : The specified node ({:x}) does not have any supvals.".format('.'.join([__name__, cls.__name__]), nodeidx, nodeidx))
         return '\n'.join(res)
@@ -512,9 +512,9 @@ class hash(object):
         except ValueError:
             l1, l2 = 0, 2
 
-        for i, key in enumerate(cls.fiter(nodeidx)):
+        for idx, key in enumerate(cls.fiter(nodeidx)):
             value = "{:<{:d}s} : default={!r}, memoryview={!r}, bytes={!r}, int={:#x}({:d})".format("{!r}".format(cls.get(nodeidx, key)), l2, cls.get(nodeidx, key, None), cls.get(nodeidx, key, memoryview), cls.get(nodeidx, key, bytes), cls.get(nodeidx, key, int), cls.get(nodeidx, key, int))
-            res.append("[{:d}] {:<{:d}s} -> {:s}".format(i, key, l1, value))
+            res.append("[{:d}] {:<{:d}s} -> {:s}".format(idx, key, l1, value))
         if not res:
             raise internal.exceptions.MissingTypeOrAttribute(u"{:s}.repr({:#x}) : The specified node ({:x}) does not have any hashvals.".format('.'.join([__name__, cls.__name__]), nodeidx, nodeidx))
         return '\n'.join(res)

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -533,7 +533,7 @@ class character(object):
     def to_hex(cls, integer):
         '''Given an integer, return the hex digit that it represents.'''
         if integer >= 0 and integer < 0x10:
-            return six.int2byte(integer + 0x30) if integer < 10 else six.int2byte(integer + 0x57)
+            return six.unichr(integer + 0x30) if integer < 10 else six.unichr(integer + 0x57)
         raise ValueError
 
     @classmethod
@@ -635,7 +635,7 @@ class character(object):
                     h, l = map(cls.of_hex, (hb.lower(), lb.lower()))
 
                     # coerce the digits into an ascii character and send the character to our result
-                    result.send(six.int2byte(
+                    result.send(six.unichr(
                         h * 0x10 |
                         l * 0x01 |
                     0))

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -548,7 +548,7 @@ class character(object):
         # begin processing any input that is fed to us
         while True:
             ch = (yield)
-            n = six.byte2int(ch)
+            n = ord(ch)
 
             # check if character has an existing escape mapping
             if cls.mapQ(ch):
@@ -757,7 +757,7 @@ class string(object):
         """
         if isinstance(item, six.string_types):
             res = cls.escape(item, '\'')
-            if all(six.byte2int(ch) < 0x100 for ch in item):
+            if all(ord(ch) < 0x100 for ch in item):
                 return "'{:s}'".format(res)
             return u"u'{:s}'".format(res)
         elif isinstance(item, tuple):

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -37,8 +37,7 @@ between its various sizes. This allows one to navigate between the
 the architecture.
 """
 
-import six
-from six.moves import builtins
+import six, builtins
 
 import functools, operator, itertools, types
 import logging, collections, math
@@ -195,7 +194,7 @@ def operands(ea):
 
     # apparently idaapi is not increasing a reference count for our operands, so we
     # need to make a copy of them quickly before we access them.
-    operands = [idaapi.op_t() for index in six.moves.range(idaapi.UA_MAXOP)]
+    operands = [idaapi.op_t() for index in range(idaapi.UA_MAXOP)]
     [ op.assign(insn.ops[index]) for index, op in enumerate(operands)]
 
     # now we can just fetch them until idaapi.o_void
@@ -252,7 +251,7 @@ def ops_repr(ea):
     '''Returns a tuple of the ``op_repr`` of all the operands for the instruction at the address `ea`.'''
     ea = interface.address.inside(ea)
     f = functools.partial(op_repr, ea)
-    return tuple(map(f, six.moves.range(ops_count(ea))))
+    return tuple(map(f, range(ops_count(ea))))
 
 @utils.multicase()
 def ops():
@@ -263,7 +262,7 @@ def ops(ea):
     '''Returns a tuple of all the operands for the instruction at the address `ea`.'''
     ea = interface.address.inside(ea)
     f = functools.partial(op, ea)
-    return tuple(map(f, six.moves.range(ops_count(ea))))
+    return tuple(map(f, range(ops_count(ea))))
 ops_value = utils.alias(ops)
 
 @utils.multicase()
@@ -278,7 +277,7 @@ def ops_size(ea):
 
     ea = interface.address.inside(ea)
     f = utils.fcompose(functools.partial(operand, ea), get_dtype_attribute, get_dtype_size, int)
-    return tuple(map(f, six.moves.range(ops_count(ea))))
+    return tuple(map(f, range(ops_count(ea))))
 
 @utils.multicase()
 def opts():
@@ -289,7 +288,7 @@ def opts(ea):
     '''Returns a tuple of the types for all the operands in the instruction at the address `ea`.'''
     ea = interface.address.inside(ea)
     f = functools.partial(opt, ea)
-    return tuple(map(f, six.moves.range(ops_count(ea))))
+    return tuple(map(f, range(ops_count(ea))))
 ops_type = utils.alias(opts)
 
 @utils.multicase()
@@ -301,11 +300,11 @@ def ops_state(ea):
     '''Returns a tuple of for all the operands containing one of the states "r", "w", or "rw" describing how the operands are modified for the instruction at address `ea`.'''
     ea = interface.address.inside(ea)
     f = type.feature(ea)
-    res = ( ((f&ops_state.read[i]), (f&ops_state.write[i])) for i in six.moves.range(ops_count(ea)) )
+    res = ( ((f & ops_state.read[i]), (f & ops_state.write[i])) for i in range(ops_count(ea)) )
     return tuple(interface.reftype_t.of_action((r and 'r' or '') + (w and 'w' or '')) for r, w in res)
 
 # pre-cache the CF_ flags from idaapi inside ops_state
-ops_state.read, ops_state.write = zip(*((getattr(idaapi, "CF_USE{:d}".format(idx + 1), 1 << (7 + idx)), getattr(idaapi, "CF_CHG{:d}".format(idx + 1), 1 << (1 + idx))) for idx in six.moves.range(idaapi.UA_MAXOP)))
+ops_state.read, ops_state.write = zip(*((getattr(idaapi, "CF_USE{:d}".format(1 + idx), 1 << (7 + idx)), getattr(idaapi, "CF_CHG{:d}".format(1 + idx), 1 << (1 + idx))) for idx in range(idaapi.UA_MAXOP)))
 
 @utils.multicase()
 def ops_read():
@@ -574,7 +573,7 @@ def op_character(ea, opnum):
         absolute //= 0x100
 
     # Last thing to do is to join each octet together back into some bytes
-    return bytes().join(map(six.int2byte, reversed(bytearray(octets))))
+    return bytes(bytearray(reversed(bytearray(octets))))
 op_chr = op_char = utils.alias(op_character)
 
 @utils.multicase(opnum=six.integer_types)
@@ -828,7 +827,7 @@ def op_structure(ea, opnum):
 
     # First we'll collect all of the IDs in our path. Then we can start by
     # grabbing the first structure id to see how we should search.
-    path = [ path[index] for index in six.moves.range(count) ]
+    path = [ path[index] for index in range(count) ]
     logging.debug(u"{:s}.op_structure({:#x}, {:d}) : Processing {:d} members ({:s}) from path that was returned from `{:s}`.".format(__name__, ea, opnum, count, ', '.join("{:#x}".format(mid) for mid in path), "{!s}({:#x}, {:d}, ...)".format('idaapi.get_stroff_path', ea, opnum)))
 
     st = structure.by_identifier(path.pop(0))
@@ -926,7 +925,7 @@ def op_structure(ea, opnum, path, **delta):
         path[0:0] = [path[0].parent]
 
     # crop elements to valid ones in case the delta is specified at the end
-    res = list(itertools.takewhile(lambda t: not isinstance(t, six.integer_types), path))
+    res = [item for item in itertools.takewhile(lambda t: not isinstance(t, six.integer_types), path)]
     if len(res) < len(path):
         res.append(path[len(res)])
 
@@ -939,7 +938,7 @@ def op_structure(ea, opnum, path, **delta):
         delta['delta'] = delta.get('delta', 0) + path.pop(-1)
 
     # figure out the structure that this all starts with
-    sptr, path = path[0].ptr, list(path)
+    sptr, path = path[0].ptr, [item for item in path]
 
     # collect each member resolving them to an id
     moff, tids = 0, []
@@ -1197,7 +1196,7 @@ def op_refs(ea, opnum):
         # now figure out the operands if there are any
         res = []
         for ea, _, t in refs:
-            ops = ((idx, internal.netnode.sup.get(ea, 0xf + idx)) for idx in six.moves.range(idaapi.UA_MAXOP) if internal.netnode.sup.get(ea, 0xf + idx) is not None)
+            ops = ((idx, internal.netnode.sup.get(ea, 0xf + idx)) for idx in range(idaapi.UA_MAXOP) if internal.netnode.sup.get(ea, 0xf + idx) is not None)
             ops = ((idx, interface.node.sup_opstruct(val, idaapi.get_inf_structure().is_64bit())) for idx, val in ops)
             ops = (idx for idx, (_, ids) in ops if st.id in ids)
             res.extend( interface.opref_t(ea, int(op), interface.reftype_t.of(t)) for op in ops)
@@ -1222,7 +1221,7 @@ def op_refs(ea, opnum):
         for ea, _, t in refs:
             if ea == idaapi.BADADDR: continue
             if database.type.flags(ea, idaapi.MS_CLS) == idaapi.FF_CODE:
-                ops = ((idx, operand(ea, idx).value if operand(ea, idx).type in {idaapi.o_imm} else operand(ea, idx).addr) for idx in six.moves.range(ops_count(ea)))
+                ops = ((idx, operand(ea, idx).value if operand(ea, idx).type in {idaapi.o_imm} else operand(ea, idx).addr) for idx in range(ops_count(ea)))
                 ops = (idx for idx, val in ops if val == gid)
                 res.extend( interface.opref_t(ea, int(op), interface.reftype_t.of(t)) for op in ops)
             else:
@@ -1447,7 +1446,7 @@ class operand_types:
 
         global architecture
         if op.type in {idaapi.o_reg}:
-            res, dt = op.reg, dtype_by_size(database.config.bits()//8)
+            res, dt = op.reg, dtype_by_size(database.config.bits() // 8)
             return architecture.by_indextype(res, get_dtype_attribute(op))
 
         optype = "{:s}({:d})".format('idaapi.o_reg', idaapi.o_reg)
@@ -1601,7 +1600,7 @@ class operand_types:
         sf, dt = 2 ** (bits - 1), dtype_by_size(database.config.bits() // 8)
 
         inverted, regular = offset & (2 ** bits - 1) if offset & sf else -2 ** bits + offset, -2 ** bits + offset if offset & sf else offset & (sf - 1)
-        res = long(inverted) if interface.node.alt_opinverted(ea, op.n) else long(regular), None if base is None else architecture.by_indextype(base, dt), None if index is None else architecture.by_indextype(index, dt), scale
+        res = inverted if interface.node.alt_opinverted(ea, op.n) else regular, None if base is None else architecture.by_indextype(base, dt), None if index is None else architecture.by_indextype(index, dt), scale
         return intelops.OffsetBaseIndexScale(*res)
 
     @__optype__.define(idaapi.PLFM_ARM, idaapi.o_phrase)
@@ -1620,7 +1619,7 @@ class operand_types:
         '''Operand type decoder for returning a memory displacement on either the AArch32 or AArch64 architectures.'''
         global architecture
         Rn = architecture.by_index(op.reg)
-        return armops.immediatephrase(Rn, long(op.addr))
+        return armops.immediatephrase(Rn, op.addr)
 
     @__optype__.define(idaapi.PLFM_ARM, idaapi.o_mem)
     def memory(ea, op):
@@ -1631,15 +1630,15 @@ class operand_types:
 
         # get the address and the operand size
         addr, size = op.addr, get_dtype_size(get_dtype_attribute(op))
-        maxval = 1<<size*8
+        maxval = 1 << size * 8
 
         # dereference the address and return its integer.
-        res = get_bytes(addr, size) or ''
-        res = reversed(res) if database.config.byteorder() == 'little' else iter(res)
-        res = reduce(lambda agg, n: (agg*0x100)|n, six.iterbytes(res), 0)
-        sf = bool(res & maxval>>1)
+        res = get_bytes(addr, size) or b''
+        res = res[::-1] if database.config.byteorder() in {'little'} else res[:]
+        res = functools.reduce(lambda agg, item: (agg * 0x100) | item, bytearray(res), 0)
+        sf = bool(res & maxval >> 1)
 
-        return armops.memory(long(addr), long(res-maxval) if sf else long(res))
+        return armops.memory(addr, res - maxval if sf else res)
 
     @__optype__.define(idaapi.PLFM_ARM, idaapi.o_idpspec0)
     def flex(ea, op):
@@ -1665,7 +1664,7 @@ class operand_types:
 
         # op.specval represents a bitmask specifying which registers are included
         specval = op.specval
-        for index in six.moves.range(16):
+        for index in range(16):
             if specval & 1:
                 res.add(architecture.by_index(index))
             specval >>= 1
@@ -2005,11 +2004,11 @@ class Intel(interface.architecture_t):
         i2s = "{:d}".format
 
         [ setitem('r'+_, self.new('r'+_, 64, _)) for _ in ('ax', 'cx', 'dx', 'bx', 'sp', 'bp', 'si', 'di', 'ip') ]
-        [ setitem('r'+_, self.new('r'+_, 64)) for _ in map(i2s, six.moves.range(8, 16)) ]
+        [ setitem('r'+_, self.new('r'+_, 64)) for _ in map(i2s, range(8, 16)) ]
         [ setitem('e'+_, self.child(self.by_name('r'+_), 'e'+_, 0, 32, _)) for _ in ('ax', 'cx', 'dx', 'bx', 'sp', 'bp', 'si', 'di', 'ip') ]
-        [ setitem('r'+_+'d', self.child(self.by_name('r'+_), 'r'+_+'d', 0, 32, idaname='r'+_)) for _ in map(i2s, six.moves.range(8, 16)) ]
-        [ setitem('r'+_+'w', self.child(self.by_name('r'+_+'d'), 'r'+_+'w', 0, 16, idaname='r'+_)) for _ in map(i2s, six.moves.range(8, 16)) ]
-        [ setitem('r'+_+'b', self.child(self.by_name('r'+_+'w'), 'r'+_+'b', 0, 8, idaname='r'+_)) for _ in map(i2s, six.moves.range(8, 16)) ]
+        [ setitem('r'+_+'d', self.child(self.by_name('r'+_), 'r'+_+'d', 0, 32, idaname='r'+_)) for _ in map(i2s, range(8, 16)) ]
+        [ setitem('r'+_+'w', self.child(self.by_name('r'+_+'d'), 'r'+_+'w', 0, 16, idaname='r'+_)) for _ in map(i2s, range(8, 16)) ]
+        [ setitem('r'+_+'b', self.child(self.by_name('r'+_+'w'), 'r'+_+'b', 0, 8, idaname='r'+_)) for _ in map(i2s, range(8, 16)) ]
         [ setitem(    _, self.child(self.by_name('e'+_), _, 0, 16)) for _ in ('ax', 'cx', 'dx', 'bx', 'sp', 'bp', 'si', 'di', 'ip') ]
         [ setitem(_+'h', self.child(self.by_name(_+'x'), _+'h', 8, 8)) for _ in ('a', 'c', 'd', 'b') ]
         [ setitem(_+'l', self.child(self.by_name(_+'x'), _+'l', 0, 8)) for _ in ('a', 'c', 'd', 'b') ]
@@ -2018,10 +2017,10 @@ class Intel(interface.architecture_t):
         setitem('fpstack', self.new('fptags', 80*8, dtype=None))    # FIXME: is this the right IDA register name??
 
         # FIXME: rex-prefixed 32-bit registers are implicitly extended to the 64-bit regs which implies that 64-bit are children of 32-bit
-        for _ in ('ax', 'cx', 'dx', 'bx', 'sp', 'bp', 'si', 'di', 'ip'):
+        for _ in ['ax', 'cx', 'dx', 'bx', 'sp', 'bp', 'si', 'di', 'ip']:
             r32, r64 = getitem('e'+_), getitem('r'+_)
             r32.alias, r64.alias = { r64 }, { r32 }
-        for _ in map(i2s, six.moves.range(8, 16)):
+        for _ in map(i2s, range(8, 16)):
             r32, r64 = getitem('r'+_+'d'), getitem('r'+_)
             r32.alias, r64.alias = { r64 }, { r32 }
 
@@ -2030,21 +2029,21 @@ class Intel(interface.architecture_t):
 
         fpstack = self.__register__.fpstack
         # single precision
-        [ setitem("st{:d}f".format(_), self.child(fpstack, "st{:d}f".format(_), _*80, 80, "st{:d}".format(_), dtype=idaapi.dt_float)) for _ in six.moves.range(8) ]
+        [ setitem("st{:d}f".format(_), self.child(fpstack, "st{:d}f".format(_), _*80, 80, "st{:d}".format(_), dtype=idaapi.dt_float)) for _ in range(8) ]
         # double precision
-        [ setitem("st{:d}d".format(_), self.child(fpstack, "st{:d}d".format(_), _*80, 80, "st{:d}".format(_), dtype=idaapi.dt_double)) for _ in six.moves.range(8) ]
+        [ setitem("st{:d}d".format(_), self.child(fpstack, "st{:d}d".format(_), _*80, 80, "st{:d}".format(_), dtype=idaapi.dt_double)) for _ in range(8) ]
         # umm..80-bit precision? i've seen op_t's in ida for fsubp with the implied st(0) using idaapi.dt_tbyte
-        [ setitem("st{:d}".format(_), self.child(fpstack, "st{:d}".format(_), _*80, 80, "st{:d}".format(_), dtype=idaapi.dt_tbyte)) for _ in six.moves.range(8) ]
+        [ setitem("st{:d}".format(_), self.child(fpstack, "st{:d}".format(_), _*80, 80, "st{:d}".format(_), dtype=idaapi.dt_tbyte)) for _ in range(8) ]
 
         # not sure if the mmx registers trash the other 16 bits of an fp register
-        [ setitem("mm{:d}".format(_), self.child(fpstack, "mm{:d}".format(_), _*80, 64, dtype=idaapi.dt_qword)) for _ in six.moves.range(8) ]
+        [ setitem("mm{:d}".format(_), self.child(fpstack, "mm{:d}".format(_), _*80, 64, dtype=idaapi.dt_qword)) for _ in range(8) ]
 
         # sse1/sse2 simd registers
-        [ setitem("xmm{:d}".format(_), self.new("xmm{:d}".format(_), 128, dtype=idaapi.dt_byte16)) for _ in six.moves.range(16) ]
-        [ setitem("ymm{:d}".format(_), self.new("ymm{:d}".format(_), 128, dtype=idaapi.dt_ldbl)) for _ in six.moves.range(16) ]
+        [ setitem("xmm{:d}".format(_), self.new("xmm{:d}".format(_), 128, dtype=idaapi.dt_byte16)) for _ in range(16) ]
+        [ setitem("ymm{:d}".format(_), self.new("ymm{:d}".format(_), 128, dtype=idaapi.dt_ldbl)) for _ in range(16) ]
 
         # control registers
-        [ setitem("cr{:d}".format(_), self.new("cr{:d}".format(_), database.config.bits())) for _ in six.moves.range(8) ]
+        [ setitem("cr{:d}".format(_), self.new("cr{:d}".format(_), database.config.bits())) for _ in range(8) ]
 
         ##fpctrl, fpstat, fptags
         ##mxcsr
@@ -2089,30 +2088,30 @@ class AArch(interface.architecture_t):
         super(AArch, self).__init__()
         getitem, setitem = self.__register__.__getattr__, self.__register__.__setattr__
 
-        [ setitem("v{:d}".format(_), self.new("v{:d}".format(_), 128, idaname="V{:d}".format(_))) for _ in six.moves.range(32) ]
-        [ setitem("q{:d}".format(_), self.new("q{:d}".format(_), 128, idaname="Q{:d}".format(_))) for _ in six.moves.range(32) ]
+        [ setitem("v{:d}".format(_), self.new("v{:d}".format(_), 128, idaname="V{:d}".format(_))) for _ in range(32) ]
+        [ setitem("q{:d}".format(_), self.new("q{:d}".format(_), 128, idaname="Q{:d}".format(_))) for _ in range(32) ]
 
-        for _ in six.moves.range(32):
+        for _ in range(32):
             rv, rq = getitem("v{:d}".format(_)), getitem("q{:d}".format(_))
             rv.alias, rq.alias = { rq }, { rv }
 
-        [ setitem("r{:d}".format(_), self.new("r{:d}".format(_), 32, idaname="R{:d}".format(_))) for _ in six.moves.range(13) ]
-        [ setitem("r{:d}h".format(_), self.child(getitem("r{:d}".format(_)), "r{:d}h".format(_), 0, 16, idaname="R{:d}".format(_))) for _ in six.moves.range(13) ]
-        [ setitem("r{:d}b".format(_), self.child(getitem("r{:d}".format(_)), "r{:d}b".format(_), 0, 8, idaname="R{:d}".format(_))) for _ in six.moves.range(13) ]
+        [ setitem("r{:d}".format(_), self.new("r{:d}".format(_), 32, idaname="R{:d}".format(_))) for _ in range(13) ]
+        [ setitem("r{:d}h".format(_), self.child(getitem("r{:d}".format(_)), "r{:d}h".format(_), 0, 16, idaname="R{:d}".format(_))) for _ in range(13) ]
+        [ setitem("r{:d}b".format(_), self.child(getitem("r{:d}".format(_)), "r{:d}b".format(_), 0, 8, idaname="R{:d}".format(_))) for _ in range(13) ]
 
         # Sub-registers that compose the V register (floating-point)
         if BITS > 32:
-            [ setitem("d{:d}".format(_), self.child(getitem("v{:d}".format(_)), "d{:d}".format(_), 0, 64, idaname="V{:d}".format(_), dtype=idaapi.dt_double)) for _ in six.moves.range(32) ]
+            [ setitem("d{:d}".format(_), self.child(getitem("v{:d}".format(_)), "d{:d}".format(_), 0, 64, idaname="V{:d}".format(_), dtype=idaapi.dt_double)) for _ in range(32) ]
         else:
-            [ setitem("d{:d}".format(_), self.child(getitem("v{:d}".format(_)), "d{:d}".format(_), 0, 64, idaname="D{:d}".format(_), dtype=idaapi.dt_double)) for _ in six.moves.range(32) ]
-        [ setitem("s{:d}".format(_), self.child(getitem("d{:d}".format(_)), "s{:d}".format(_), 0, 32, idaname="S{:d}".format(_), dtype=idaapi.dt_float)) for _ in six.moves.range(32) ]
-        [ setitem("h{:d}".format(_), self.child(getitem("s{:d}".format(_)), "h{:d}".format(_), 0, 16, idaname="X{:d}".format(_), dtype=getattr(idaapi, 'dt_half', idaapi.dt_word))) for _ in six.moves.range(32) ]
-        [ setitem("b{:d}".format(_), self.child(getitem("h{:d}".format(_)), "b{:d}".format(_), 0, 8, idaname="X{:d}".format(_))) for _ in six.moves.range(32) ]
+            [ setitem("d{:d}".format(_), self.child(getitem("v{:d}".format(_)), "d{:d}".format(_), 0, 64, idaname="D{:d}".format(_), dtype=idaapi.dt_double)) for _ in range(32) ]
+        [ setitem("s{:d}".format(_), self.child(getitem("d{:d}".format(_)), "s{:d}".format(_), 0, 32, idaname="S{:d}".format(_), dtype=idaapi.dt_float)) for _ in range(32) ]
+        [ setitem("h{:d}".format(_), self.child(getitem("s{:d}".format(_)), "h{:d}".format(_), 0, 16, idaname="X{:d}".format(_), dtype=getattr(idaapi, 'dt_half', idaapi.dt_word))) for _ in range(32) ]
+        [ setitem("b{:d}".format(_), self.child(getitem("h{:d}".format(_)), "b{:d}".format(_), 0, 8, idaname="X{:d}".format(_))) for _ in range(32) ]
 
         # General-purpose registers
-        [ setitem("x{:d}".format(_), self.new("x{:d}".format(_), BITS, idaname="X{:d}".format(_))) for _ in six.moves.range(31) ]
+        [ setitem("x{:d}".format(_), self.new("x{:d}".format(_), BITS, idaname="X{:d}".format(_))) for _ in range(31) ]
         if BITS > 32:
-            [ setitem("w{:d}".format(_), self.child(self.by_name("x{:d}".format(_)), "w{:d}".format(_), 0, 32, idaname="X{:d}".format(_))) for _ in six.moves.range(31) ]
+            [ setitem("w{:d}".format(_), self.child(self.by_name("x{:d}".format(_)), "w{:d}".format(_), 0, 32, idaname="X{:d}".format(_))) for _ in range(31) ]
         setitem('lr', self.new('lr', BITS, idaname='LR', alias={'x31'}))
 
         # Zero registers and special regs
@@ -2288,19 +2287,19 @@ class MIPS(interface.architecture_t):
         setitem('ra', self.new('ra', BITS, idaname='$ra'))
         setitem('pc', self.new('pc', BITS))
 
-        [ setitem("v{:d}".format(_), self.new("v{:d}".format(_), BITS, idaname="$v{:d}".format(_))) for _ in six.moves.range(2) ]
-        [ setitem("a{:d}".format(_), self.new("a{:d}".format(_), BITS, idaname="$a{:d}".format(_))) for _ in six.moves.range(8) ]
-        [ setitem("t{:d}".format(_), self.new("t{:d}".format(_), BITS, idaname="$t{:d}".format(_))) for _ in six.moves.range(0, 10) ]
-        [ setitem("s{:d}".format(_), self.new("s{:d}".format(_), BITS, idaname="$s{:d}".format(_))) for _ in six.moves.range(8) ]
-        [ setitem("k{:d}".format(_), self.new("k{:d}".format(_), BITS, idaname="$k{:d}".format(_))) for _ in six.moves.range(2) ]
+        [ setitem("v{:d}".format(_), self.new("v{:d}".format(_), BITS, idaname="$v{:d}".format(_))) for _ in range(2) ]
+        [ setitem("a{:d}".format(_), self.new("a{:d}".format(_), BITS, idaname="$a{:d}".format(_))) for _ in range(8) ]
+        [ setitem("t{:d}".format(_), self.new("t{:d}".format(_), BITS, idaname="$t{:d}".format(_))) for _ in range(0, 10) ]
+        [ setitem("s{:d}".format(_), self.new("s{:d}".format(_), BITS, idaname="$s{:d}".format(_))) for _ in range(8) ]
+        [ setitem("k{:d}".format(_), self.new("k{:d}".format(_), BITS, idaname="$k{:d}".format(_))) for _ in range(2) ]
 
         # FIXME: add the register definitions for : cs, ds, mips16
 
         # floating-point registers
         if BITS > 32:
-            [ setitem("f{:d}".format(_), self.new("f{:d}".format(_), BITS, idaname="$f{:d}".format(_), dtype=idaapi.dt_double)) for _ in six.moves.range(32) ]
+            [ setitem("f{:d}".format(_), self.new("f{:d}".format(_), BITS, idaname="$f{:d}".format(_), dtype=idaapi.dt_double)) for _ in range(32) ]
         else:
-            [ setitem("f{:d}".format(_), self.new("f{:d}".format(_), BITS, idaname="$f{:d}".format(_), dtype=idaapi.dt_float)) for _ in six.moves.range(32) ]
+            [ setitem("f{:d}".format(_), self.new("f{:d}".format(_), BITS, idaname="$f{:d}".format(_), dtype=idaapi.dt_float)) for _ in range(32) ]
 
         # FIXME: we should probably include all of the selector versions for the
         #        coprocessor registers too...

--- a/base/structure.py
+++ b/base/structure.py
@@ -522,9 +522,9 @@ class structure_t(object):
         d2 = internal.comment.decode(res)
 
         # check for duplicate keys
-        if d1.viewkeys() & d2.viewkeys():
+        if six.viewkeys(d1) & six.viewkeys(d2):
             cls = self.__class__
-            logging.info(u"{:s}({:#x}).comment() : Contents of both the repeatable and non-repeatable comment conflict with one another due to using the same keys ({!r}). Giving the {:s} comment priority.".format('.'.join([__name__, cls.__name__]), self.id, ', '.join(d1.viewkeys() & d2.viewkeys()), 'repeatable' if repeatable else 'non-repeatable'))
+            logging.info(u"{:s}({:#x}).comment() : Contents of both the repeatable and non-repeatable comment conflict with one another due to using the same keys ({!r}). Giving the {:s} comment priority.".format('.'.join([__name__, cls.__name__]), self.id, ', '.join(six.viewkeys(d1) & six.viewkeys(d2)), 'repeatable' if repeatable else 'non-repeatable'))
 
         # merge the dictionaries into one and return it (XXX: return a dictionary that automatically updates the comment when it's updated)
         res = {}
@@ -1631,9 +1631,9 @@ class member_t(object):
         d2 = internal.comment.decode(res)
 
         # check for duplicate keys
-        if d1.viewkeys() & d2.viewkeys():
+        if six.viewkeys(d1) & six.viewkeys(d2):
             cls = self.__class__
-            logging.info(u"{:s}({:#x}).comment : Contents of both the repeatable and non-repeatable comment conflict with one another due to using the same keys ({!r}). Giving the {:s} comment priority.".format('.'.join([__name__, cls.__name__]), self.id, ', '.join(d1.viewkeys() & d2.viewkeys()), 'repeatable' if repeatable else 'non-repeatable'))
+            logging.info(u"{:s}({:#x}).comment : Contents of both the repeatable and non-repeatable comment conflict with one another due to using the same keys ({!r}). Giving the {:s} comment priority.".format('.'.join([__name__, cls.__name__]), self.id, ', '.join(six.viewkeys(d1) & six.viewkeys(d2)), 'repeatable' if repeatable else 'non-repeatable'))
 
         # merge the dictionaries into one and return it
         # XXX: it'd be cool to return an object with a dictionary

--- a/base/structure.py
+++ b/base/structure.py
@@ -39,8 +39,7 @@ Some examples of using these keywords are as follows::
 
 """
 
-import six
-from six.moves import builtins
+import six, builtins
 
 import functools, operator, itertools, types
 import sys, logging
@@ -110,11 +109,11 @@ def iterate(string):
 @utils.string.decorate_arguments('regex', 'like', 'name')
 def iterate(**type):
     '''Iterate through all of the structures that match the keyword specified by `type`.'''
-    if not type: type = {'predicate':lambda n: True}
-    res = builtins.list(__iterate__())
-    for key, value in six.iteritems(type):
-        res = builtins.list(__matcher__.match(key, value, res))
-    for item in res: yield item
+    if not type: type = {'predicate': lambda item: True}
+    listable = [item for item in __iterate__()]
+    for key, value in type.items():
+        listable = [item for item in __matcher__.match(key, value, listable)]
+    for item in listable: yield item
 
 @utils.multicase(string=six.string_types)
 @utils.string.decorate_arguments('string')
@@ -125,7 +124,7 @@ def list(string):
 @utils.string.decorate_arguments('regex', 'like', 'name')
 def list(**type):
     '''List all the structures within the database that match the keyword specified by `type`.'''
-    res = builtins.list(iterate(**type))
+    res = [item for item in iterate(**type)]
 
     maxindex = max(builtins.map(utils.fcompose(operator.attrgetter('index'), "{:d}".format, len), res) if res else [1])
     maxname = max(builtins.map(utils.fcompose(operator.attrgetter('name'), utils.fdefault(''), len), res) if res else [1])
@@ -173,12 +172,14 @@ def by(**type):
     '''Return the structure matching the keyword specified by `type`.'''
     searchstring = utils.string.kwargs(type)
 
-    res = builtins.list(iterate(**type))
-    if len(res) > 1:
-        map(logging.info, ((u"[{:d}] {:s}".format(idaapi.get_struc_idx(st.id), st.name)) for i, st in enumerate(res)))
-        logging.warning(u"{:s}.search({:s}) : Found {:d} matching results, returning the first one {!s}.".format(__name__, searchstring, len(res), res[0]))
+    listable = [item for item in iterate(**type)]
+    if len(listable) > 1:
+        messages = ((u"[{:d}] {:s}".format(idaapi.get_struc_idx(st.id), st.name)) for i, st in enumerate(listable))
+        [ logging.info(msg) for msg in messages ]
+        logging.warning(u"{:s}.search({:s}) : Found {:d} matching results, returning the first one {!s}.".format(__name__, searchstring, len(listable), listable[0]))
 
-    res = next(iter(res), None)
+    iterable = (item for item in listable)
+    res = next(iterable, None)
     if res is None:
         raise E.SearchResultsError(u"{:s}.search({:s}) : Found 0 matching results.".format(__name__, searchstring))
     return res
@@ -425,10 +426,10 @@ class structure_t(object):
         return self.__members__
 
     def __getstate__(self):
-        cmtt, cmtf = map(functools.partial(idaapi.get_struc_cmt, self.id), (True, False))
+        cmtt, cmtf = map(functools.partial(idaapi.get_struc_cmt, self.id), [True, False])
 
         # decode the comments that we found in the structure
-        res = map(utils.string.of, (cmtt, cmtf))
+        res = (utils.string.of(cmt) for cmt in [cmtt, cmtf])
 
         # FIXME: perhaps we should preserve the get_struc_idx result too
         return (self.name, tuple(res), self.members)
@@ -527,7 +528,7 @@ class structure_t(object):
 
         # merge the dictionaries into one and return it (XXX: return a dictionary that automatically updates the comment when it's updated)
         res = {}
-        builtins.map(res.update, (d1, d2) if repeatable else (d2, d1))
+        [res.update(d) for d in ([d1, d2] if repeatable else [d2, d1])]
         return res
     @utils.multicase(key=six.string_types)
     @utils.string.decorate_arguments('key')
@@ -769,7 +770,7 @@ def members(id):
 
     # iterate through the number of members belonging to the struct
     offset = 0
-    for i in six.moves.range(st.memqty):
+    for i in range(st.memqty):
 
         # grab the member and its size
         m = st.get_member(i)
@@ -786,10 +787,11 @@ def members(id):
             offset = left
 
         # grab the member's attributes
-        res = map(utils.string.of, (idaapi.get_member_name(m.id), idaapi.get_member_cmt(m.id, 0), idaapi.get_member_cmt(m.id, 1)))
+        iterable = (utils.string.of(cmt) for cmt in [idaapi.get_member_name(m.id), idaapi.get_member_cmt(m.id, 0), idaapi.get_member_cmt(m.id, 1)])
+        items = builtins.tuple(iterable)
 
         # yield our current position and iterate to the next member
-        yield (offset, ms), tuple(res)
+        yield (offset, ms), items
         offset += ms
     return
 
@@ -909,7 +911,8 @@ class members_t(object):
         self.baseoffset = baseoffset
 
     def __getstate__(self):
-        return (self.parent.name, self.baseoffset, map(self.__getitem__, six.moves.range(len(self))))
+        items = [self[idx] for idx in range(len(self))]
+        return (self.parent.name, self.baseoffset, items)
     def __setstate__(self, state):
         parentname, baseoffset, _ = state
 
@@ -932,7 +935,7 @@ class members_t(object):
         return 0 if self.parent.ptr is None else self.parent.ptr.memqty
     def __iter__(self):
         '''Yield all the members within the structure.'''
-        for idx in six.moves.range(len(self)):
+        for idx in range(len(self)):
             yield member_t(self.parent, idx)
         return
     def __getitem__(self, index):
@@ -943,7 +946,8 @@ class members_t(object):
         elif isinstance(index, six.string_types):
             res = self.by_name(index)
         elif isinstance(index, slice):
-            res = [self.__getitem__(i) for i in six.moves.range(self.parent.ptr.memqty)].__getitem__(index)
+            sliceable = [self[idx] for idx in range(self.parent.ptr.memqty)]
+            res = sliceable[index]
         else:
             cls = self.__class__
             raise E.InvalidParameterError(u"{:s}({:#x}).members.__getitem__({!r}) : An invalid type ({!r}) was specified for the index.".format('.'.join([__name__, cls.__name__]), self.parent.id, index, index.__class__))
@@ -959,7 +963,7 @@ class members_t(object):
             cls = self.__class__
             raise E.InvalidParameterError(u"{:s}({:#x}).members.index({!r}) : An invalid type ({!r}) was specified for the member to search for.".format('.'.join([__name__, cls.__name__]), self.parent.id, member, member.__class__))
 
-        for i in six.moves.range(self.parent.ptr.memqty):
+        for i in range(self.parent.ptr.memqty):
             if member.id == self[i].id:
                 return i
             continue
@@ -988,11 +992,11 @@ class members_t(object):
     @utils.multicase()
     def iterate(self, **type):
         '''Iterate through all of the members in the structure that match the keyword specified by `type`.'''
-        if not type: type = {'predicate':lambda n: True}
-        res = builtins.list(iter(self))
-        for key, value in six.iteritems(type):
-            res = builtins.list(self.__member_matcher.match(key, value, res))
-        for item in res: yield item
+        if not type: type = {'predicate': lambda item: True}
+        listable = [item for item in self]
+        for key, value in type.items():
+            listable = [item for item in self.__member_matcher.match(key, value, listable)]
+        for item in listable: yield item
     @utils.multicase(string=six.string_types)
     @utils.string.decorate_arguments('string')
     def iterate(self, string):
@@ -1008,7 +1012,7 @@ class members_t(object):
     @utils.string.decorate_arguments('regex', 'name', 'like', 'fullname', 'comment', 'comments')
     def list(self, **type):
         '''List all the members within the structure that match the keyword specified by `type`.'''
-        res = builtins.list(self.iterate(**type))
+        res = [item for item in self.iterate(**type)]
 
         maxindex = max(builtins.map(utils.fcompose(operator.attrgetter('index'), "{:d}".format, len), res) if res else [1])
         maxoffset = max(builtins.map(utils.fcompose(operator.attrgetter('offset'), "{:x}".format, len), res) if res else [1])
@@ -1027,13 +1031,15 @@ class members_t(object):
         '''Return the member that matches the keyword specified by `type`.'''
         searchstring = utils.string.kwargs(type)
 
-        res = builtins.list(self.iterate(**type))
-        if len(res) > 1:
+        listable = [item for item in self.iterate(**type)]
+        if len(listable) > 1:
             cls = self.__class__
-            map(logging.info, ((u"[{:d}] {:x}{:+#x} {:s} '{:s}' {!r}".format(m.index, m.offset, m.size, "{!s}".format(m.typeinfo.dstr()).replace(' *', '*'), utils.string.escape(m.name, '\''), m.type)) for m in res))
-            logging.warning(u"{:s}({:#x}).members.by({:s}) : Found {:d} matching results. Returning the member at index {:d} offset {:x}{:+#x} with the name \"{:s}\" and typeinfo \"{:s}\".".format('.'.join([__name__, cls.__name__]), self.parent.id, searchstring, len(res), res[0].index, res[0].offset, res[0].size, utils.string.escape(res[0].fullname, '"'), utils.string.escape("{!s}".format(res[0].typeinfo.dstr()).replace(' *', '*'), '"')))
+            messages = ((u"[{:d}] {:x}{:+#x} {:s} '{:s}' {!r}".format(m.index, m.offset, m.size, "{!s}".format(m.typeinfo.dstr()).replace(' *', '*'), utils.string.escape(m.name, '\''), m.type)) for m in listable)
+            [ logging.info(msg) for msg in messages ]
+            logging.warning(u"{:s}({:#x}).members.by({:s}) : Found {:d} matching results. Returning the member at index {:d} offset {:x}{:+#x} with the name \"{:s}\" and typeinfo \"{:s}\".".format('.'.join([__name__, cls.__name__]), self.parent.id, searchstring, len(listable), listable[0].index, listable[0].offset, listable[0].size, utils.string.escape(listable[0].fullname, '"'), utils.string.escape("{!s}".format(listable[0].typeinfo.dstr()).replace(' *', '*'), '"')))
 
-        res = next(iter(res), None)
+        iterable = (item for item in listable)
+        res = next(iterable, None)
         if res is None:
             cls = self.__class__
             raise E.SearchResultsError(u"{:s}({:#x}).members.by({:s}) : Found 0 matching results.".format('.'.join([__name__, cls.__name__]), self.parent.id, searchstring))
@@ -1086,7 +1092,7 @@ class members_t(object):
 
         # Start out by getting our bounds, and translating them to our relative
         # offset.
-        min, max = map(lambda offset: offset + self.baseoffset, (idaapi.get_struc_first_offset(self.parent.ptr), idaapi.get_struc_last_offset(self.parent.ptr)))
+        min, max = map(lambda offset: offset + self.baseoffset, [idaapi.get_struc_first_offset(self.parent.ptr), idaapi.get_struc_last_offset(self.parent.ptr)])
 
         # Guard against a potential OverflowError that would be raised by SWIG's typechecking
         if self.baseoffset > max:
@@ -1226,7 +1232,7 @@ class members_t(object):
 
     def near_offset(self, offset):
         '''Return the member nearest to the specified `offset` from the base offset of the structure.'''
-        min, max = map(lambda sz: sz + self.baseoffset, (idaapi.get_struc_first_offset(self.parent.ptr), idaapi.get_struc_last_offset(self.parent.ptr)))
+        min, max = map(lambda sz: sz + self.baseoffset, [idaapi.get_struc_first_offset(self.parent.ptr), idaapi.get_struc_last_offset(self.parent.ptr)])
         if (offset < min) or (offset >= max):
             cls = self.__class__
             logging.info(u"{:s}({:#x}).members.near_offset({:+#x}) : Requested offset not within bounds {:#x}<->{:#x}. Trying anyways..".format('.'.join([__name__, cls.__name__]), self.parent.id, offset, min, max))
@@ -1369,7 +1375,7 @@ class members_t(object):
         '''Display all the fields within the specified structure.'''
         res = []
         mn, ms, mti = 0, 0, 0
-        for i in six.moves.range(len(self)):
+        for i in range(len(self)):
             m = self[i]
             name, t, ti, ofs, size, comment, tag = m.name, m.type, m.typeinfo, m.offset, m.size, m.comment, m.tag()
             res.append((i, name, t, ti, ofs, size, comment or '', tag))
@@ -1380,7 +1386,7 @@ class members_t(object):
         mi = len("{:d}".format(len(self) - 1)) if len(self) else 1
 
         if len(self):
-            mo = max(map(len, map("{:x}".format, (self.baseoffset, self[-1].offset + self[-1].size))))
+            mo = max(map(len, map("{:x}".format, [self.baseoffset, self[-1].offset + self[-1].size])))
             return "{!r}\n{:s}".format(self.parent, '\n'.join("[{:{:d}d}] {:>{:d}x}{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {!s} {:s}".format(i, mi, o, mo, s, ms, "{!s}".format(ti.dstr()).replace(' *','*'), mti, utils.string.repr(n), mn+2, utils.string.repr(t), " // {!s}".format(utils.string.repr(T) if '\n' in c else utils.string.to(c)) if c else '') for i, n, t, ti, o, s, c, T in res))
         return "{!r}".format(self.parent)
 
@@ -1430,7 +1436,7 @@ class member_t(object):
         # grab its comments
         cmtt = idaapi.get_member_cmt(self.id, True)
         cmtf = idaapi.get_member_cmt(self.id, False)
-        res = map(utils.string.of, (cmtt, cmtf))
+        res = (utils.string.of(cmt) for cmt in [cmtt, cmtf])
 
         # now we can return them
         ofs = self.offset - self.__parent.members.baseoffset
@@ -1634,7 +1640,7 @@ class member_t(object):
         #      that automatically synchronizes itself to the
         #      comment when a value is actually updated.
         res = {}
-        builtins.map(res.update, (d1, d2) if repeatable else (d2, d1))
+        [res.update(d) for d in ([d1, d2] if repeatable else [d2, d1])]
         return res
     @utils.multicase(key=six.string_types)
     @utils.string.decorate_arguments('key')
@@ -1839,7 +1845,7 @@ class member_t(object):
         # now figure out which operand has the structure member applied to it
         res = []
         for ea, _, t in refs:
-            iterable = ((idx, internal.netnode.sup.get(ea, 0xf + idx, type=memoryview)) for idx in six.moves.range(idaapi.UA_MAXOP) if internal.netnode.sup.get(ea, 0xf + idx) is not None)
+            iterable = ((idx, internal.netnode.sup.get(ea, 0xf + idx, type=memoryview)) for idx in range(idaapi.UA_MAXOP) if internal.netnode.sup.get(ea, 0xf + idx) is not None)
             listable = [(idx, view.tobytes()) for idx, view in iterable]
 
             # check if we found any ops that point directly to this member
@@ -1864,7 +1870,7 @@ class member_t(object):
                 # are pointing to our structure member.
                 # pointing at our member exactly..
                 for opnum, ri, opvalue in iterable:
-                    offset = opvalue if isinstance(opvalue, six.integer_types) else six.next((getattr(opvalue, attribute) for attribute in {'offset', 'address'} if hasattr(opvalue, attribute)), None)
+                    offset = opvalue if isinstance(opvalue, six.integer_types) else builtins.next((getattr(opvalue, attribute) for attribute in {'offset', 'address'} if hasattr(opvalue, attribute)), None)
 
                     # check if we got a valid offset, because if not then we just
                     # need to skip to the next iteration

--- a/custom/tagfix.py
+++ b/custom/tagfix.py
@@ -119,9 +119,9 @@ def fetch_globals():
     # consolidate tags into individual dictionaries
     six.print_(u'globals: aggregating results', file=output)
     addr, tags = dict(faddr), dict(ftags)
-    for k, v in six.iteritems(daddr):
+    for k, v in daddr.items():
         addr[k] = addr.get(k, 0) + v
-    for k, v in six.iteritems(dtags):
+    for k, v in dtags.items():
         tags[k] = tags.get(k, 0) + v
 
     six.print_(u"globals: found {:d} addresses".format(len(addr)), file=output)
@@ -142,7 +142,7 @@ def contents(ea):
     f, addr, tags = fetch_contents(ea)
 
     # clean out any hidden tag values
-    for k in six.viewkeys(tags):
+    for k in tags.keys():
         if k in {'__tags__', '__address__'}:
             if f in addr:
                 addr[f] -= 1
@@ -157,11 +157,11 @@ def contents(ea):
     # update addresses and tags to contents
     ui.navigation.set(ea)
     logging.debug(u"{:s}.contents({:#x}): Updating the name reference cache for the contents of function {:#x}.".format('.'.join([__name__]), ea, ea))
-    for k, v in six.iteritems(tags):
+    for k, v in tags.items():
         internal.comment.contents.set_name(f, k, v)
 
     logging.debug(u"{:s}.contents({:#x}): Updating the address reference cache for the contents of function {:#x}.".format('.'.join([__name__]), ea, ea))
-    for k, v in six.iteritems(addr):
+    for k, v in addr.items():
         if not func.within(k):
             continue
         internal.comment.contents.set_address(k, v)
@@ -176,11 +176,11 @@ def globals():
 
     # update the global state
     six.print_(u'globals: updating global name refs', file=output)
-    for k, v in six.iteritems(tags):
+    for k, v in tags.items():
         internal.comment.globals.set_name(k, v)
 
     six.print_(u'globals: updating global address refs', file=output)
-    for k, v in six.iteritems(addr):
+    for k, v in addr.items():
         internal.comment.globals.set_address(k, v)
 
     return addr, tags
@@ -216,10 +216,10 @@ def extracomments():
         ctx = internal.comment.contents if func.within(ea) else internal.comment.globals
 
         count = db.extra.__count__(ea, idaapi.E_PREV)
-        if count: [ ctx.inc(ea, '__extra_prefix__') for i in six.moves.range(count) ]
+        if count: [ ctx.inc(ea, '__extra_prefix__') for i in range(count) ]
 
         count = db.extra.__count__(ea, idaapi.E_NEXT)
-        if count: [ ctx.inc(ea, '__extra_suffix__') for i in six.moves.range(count) ]
+        if count: [ ctx.inc(ea, '__extra_suffix__') for i in range(count) ]
     return
 
 def everything():

--- a/custom/windbg.py
+++ b/custom/windbg.py
@@ -67,7 +67,7 @@ def escape(input, depth=0, **extra):
     # result into a string anyways.
     def closure(input, depth, extra):
         bs = '\\'
-        ws = { six.int2byte(i) : item for i, item in enumerate('0123456abtnvfr') }
+        ws = { six.unichr(i) : item for i, item in enumerate('0123456abtnvfr') }
         escaped = {bs, '"'}
 
         # Now we can tokenize our input and figure out what it's supposed to yield

--- a/custom/windbg.py
+++ b/custom/windbg.py
@@ -36,10 +36,10 @@ def tokenize(input, escapables={"'", '"', '\\'} | {item for item in string.white
 
     If the set `escapables` is defined, then use it as the list of characters to tokenize.
     """
-    result, iterable = '', iter(input)
+    result, iterable = '', (item for item in input)
     try:
         while True:
-            char = six.next(iterable)
+            char = builtins.next(iterable)
             if operator.contains(escapables, char):
                 if result:
                     yield result
@@ -88,7 +88,7 @@ def escape(input, depth=0, **extra):
                 # Add any characters that were explicitly specified in the
                 # "extra" dictionary, and replace our current token with it
                 if any(operator.contains(token, item) for item in extra):
-                    k = six.next(item for item in extra if operator.contains(token, item))
+                    k = builtins.next(item for item in extra if operator.contains(token, item))
                     token = token.replace(k, extra[k] * depth + k)
 
                 # Now we can yield our token
@@ -119,7 +119,7 @@ def breakpoints(f=None, **kwargs):
     tags, select = {}, itertools.chain(func.select(f, And=(tagname,), Or=('',)))
     for ea, t in select:
         h = tags.setdefault(ea, {})
-        for k in six.iterkeys(t):
+        for k in t.keys():
             if k == tagname:
                 h.setdefault(k, []).extend(t[k] if isinstance(t[k], builtins.list) else t[k].split(';'))
 
@@ -132,7 +132,7 @@ def breakpoints(f=None, **kwargs):
         continue
 
     # aggregate all of the discovered tags into a list of breakpoints
-    for ea, t in six.iteritems(tags):
+    for ea, t in tags.items():
         ofs, commands = db.offset(ea), []
 
         # create the command that emits the current label
@@ -147,7 +147,7 @@ def breakpoints(f=None, **kwargs):
             commands.append(res)
 
         # escape all of the commands since we're going to join them together
-        commands = map(escape, commands)
+        commands = (escape(cmd) for cmd in commands)
 
-        print 'bp {:s} "{:s}"'.format(reference(ea, **kwargs), escape(';'.join(commands), depth=1))
+        six.print_('bp {:s} "{:s}"'.format(reference(ea, **kwargs), escape(';'.join(commands), depth=1)))
     return

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -70,8 +70,9 @@ class address(commentbase):
     def _update_refs(cls, ea, old, new):
         f, rt = cls.get_func_extern(ea)
 
-        logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}){:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys()), ' for runtime-linked function' if rt else ''))
-        for key in old.viewkeys() ^ new.viewkeys():
+        oldkeys, newkeys = ({item for item in content.keys()} for content in [old, new])
+        logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}){:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(oldkeys), utils.string.repr(newkeys), ' for runtime-linked function' if rt else ''))
+        for key in oldkeys ^ newkeys:
             if key not in new:
                 logging.debug(u"{:s}.update_refs({:#x}) : Decreasing reference count for {!s} at {:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(key), 'address', ea))
                 if f and not rt: internal.comment.contents.dec(ea, key)
@@ -84,22 +85,24 @@ class address(commentbase):
         return
 
     @classmethod
-    def _create_refs(cls, ea, res):
+    def _create_refs(cls, ea, content):
         f, rt = cls.get_func_extern(ea)
 
-        logging.debug(u"{:s}.create_refs({:#x}) : Creating keys ({!s}){:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(res.viewkeys()), ' for runtime-linked function' if rt else ''))
-        for key in res.viewkeys():
+        contentkeys = {item for item in content.keys()}
+        logging.debug(u"{:s}.create_refs({:#x}) : Creating keys ({!s}){:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(contentkeys), ' for runtime-linked function' if rt else ''))
+        for key in contentkeys:
             logging.debug(u"{:s}.create_refs({:#x}) : Increasing reference count for {!s} at {:s} {:#x}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(key), 'address', ea))
             if f and not rt: internal.comment.contents.inc(ea, key)
             else: internal.comment.globals.inc(ea, key)
         return
 
     @classmethod
-    def _delete_refs(cls, ea, res):
+    def _delete_refs(cls, ea, content):
         f, rt = cls.get_func_extern(ea)
 
-        logging.debug(u"{:s}.delete_refs({:#x}) : Deleting keys ({!s}){:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(res.viewkeys()), ' from runtime-linked function' if rt else ''))
-        for key in res.viewkeys():
+        contentkeys = {item for item in content.keys()}
+        logging.debug(u"{:s}.delete_refs({:#x}) : Deleting keys ({!s}){:s}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(contentkeys), ' from runtime-linked function' if rt else ''))
+        for key in contentkeys:
             logging.debug(u"{:s}.delete_refs({:#x}) : Decreasing reference count for {!s} at {:s} {:#x}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(key), 'address', ea))
             if f and not rt: internal.comment.contents.dec(ea, key)
             else: internal.comment.globals.dec(ea, key)
@@ -261,8 +264,9 @@ class address(commentbase):
 class globals(commentbase):
     @classmethod
     def _update_refs(cls, fn, old, new):
-        logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}).".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(old.viewkeys()), utils.string.repr(new.viewkeys())))
-        for key in old.viewkeys() ^ new.viewkeys():
+        oldkeys, newkeys = ({item for item in content.keys()} for content in [old, new])
+        logging.debug(u"{:s}.update_refs({:#x}) : Updating old keys ({!s}) to new keys ({!s}).".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(oldkeys), utils.string.repr(newkeys)))
+        for key in oldkeys ^ newkeys:
             if key not in new:
                 logging.debug(u"{:s}.update_refs({:#x}) : Decreasing reference count for {!s} at {:s} {:#x}.".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
                 internal.comment.globals.dec(interface.range.start(fn), key)
@@ -273,17 +277,19 @@ class globals(commentbase):
         return
 
     @classmethod
-    def _create_refs(cls, fn, res):
-        logging.debug(u"{:s}.create_refs({:#x}) : Creating keys ({!s}).".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(res.viewkeys())))
-        for key in res.viewkeys():
+    def _create_refs(cls, fn, content):
+        contentkeys = {item for item in content.keys()}
+        logging.debug(u"{:s}.create_refs({:#x}) : Creating keys ({!s}).".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(contentkeys)))
+        for key in contentkeys:
             logging.debug(u"{:s}.create_refs({:#x}) : Increasing reference count for {!s} at {:s} {:#x}.".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
             internal.comment.globals.inc(interface.range.start(fn), key)
         return
 
     @classmethod
-    def _delete_refs(cls, fn, res):
-        logging.debug(u"{:s}.delete_refs({:#x}) : Deleting keys ({!s}).".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(res.viewkeys())))
-        for key in res.viewkeys():
+    def _delete_refs(cls, fn, content):
+        contentkeys = {item for item in content.keys()}
+        logging.debug(u"{:s}.delete_refs({:#x}) : Deleting keys ({!s}).".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(contentkeys)))
+        for key in contentkeys:
             logging.debug(u"{:s}.delete_refs({:#x}) : Decreasing reference count for {!s} at {:s} {:#x}.".format('.'.join([__name__, cls.__name__]), interface.range.start(fn) if fn else idaapi.BADADDR, utils.string.repr(key), 'function' if fn else 'global', interface.range.start(fn)))
             internal.comment.globals.dec(interface.range.start(fn), key)
         return
@@ -563,7 +569,7 @@ def __process_functions(percentage=0.10):
     p.open()
     six.print_(u"Pre-building tagcache for {:d} functions.".format(len(funcs)))
     for i, fn in enumerate(funcs):
-        chunks = list(function.chunks(fn))
+        chunks = [item for item in function.chunks(fn)]
 
         text = functools.partial(u"Processing function {:#x} ({chunks:d} chunk{plural:s}) -> {:d} of {:d}".format, fn, 1 + i, len(funcs))
         p.update(current=i)
@@ -596,7 +602,7 @@ def rebase(info):
     through all of the known global tags and then transform those.
     """
     get_segment_name = idaapi.get_segm_name if hasattr(idaapi, 'get_segm_name') else idaapi.get_true_segm_name
-    functions, globals = map(utils.fcompose(sorted, list), (database.functions(), internal.netnode.alt.fiter(internal.comment.tagging.node())))
+    functions, globals = map(utils.fcompose(sorted, list), [database.functions(), internal.netnode.alt.fiter(internal.comment.tagging.node())])
 
     p = ui.Progress()
     p.update(current=0, title=u"Rebasing tagcache...", min=0, max=sum(len(item) for item in [functions, globals]))
@@ -636,7 +642,7 @@ def rebase(info):
 
 def __rebase_function(old, new, size, iterable):
     key = internal.comment.tagging.__address__
-    failure, total = [], list(iterable)
+    failure, total = [], [item for item in iterable]
 
     for i, fn in enumerate(total):
         offset = fn - new
@@ -675,7 +681,7 @@ def __rebase_function(old, new, size, iterable):
 
 def __rebase_globals(old, new, size, iterable):
     node = internal.comment.tagging.node()
-    failure, total = [], list(iterable)
+    failure, total = [], [item for item in iterable]
     for i, (ea, count) in enumerate(total):
         offset = ea - old
 

--- a/misc/tools.py
+++ b/misc/tools.py
@@ -120,7 +120,7 @@ def recovermarks():
         if m != { ea for ea, _ in res }:
             logging.warning("{:s} : Ignoring the function tag \"{:s}\" for function {:#x} due to its value being out-of-sync with the contents values ({!s} <> {!s}).".format('.'.join([__name__, 'recovermarks']), fn, builtins.map("{:#x}".format, m), builtins.map("{:#x}".format, {ea for ea, _ in res})))
         result.extend(res)
-    result.sort(cmp=lambda x, y: cmp(x[1], y[1]))
+    result.sort(key=lambda item: item[1])
 
     # discovered marks versus database marks
     result = {ea : item for ea, item in result.items()}
@@ -163,7 +163,7 @@ def checkmarks():
         continue
 
     d = listable[:]
-    d.sort( lambda a, b: cmp(a[0], b[0]) )
+    d.sort(key=lambda item: item[0])
 
     flookup = {}
     for fn, a, m in d:


### PR DESCRIPTION
Python3 removes a number of dictionary iterator methods such as `dict.iterkeys`, `dict.itervalues`, and `dict.iteritems`. It has also deprecated a number of dictionary set methods such as `dict.viewkeys`, `dict.viewvalues`, and `dict.viewitems` since the `dict.keys`, `dict.values`, and `dict.items` methods now return the `dict_keys`, `dict_values`, and `dict_items` types (respectively). Although the `six` module provides wrappers for these methods that are compatible between both Python2 and Python3, we can actually accomplish compatibility without the `six` module wrappers.

This PR does exactly that by using the native `dict.keys`, `dict.values`, and `dict.items` methods when iterating through them. Whenever the situation arises where set operations need to be applied to the keys of a dictionary, then the keys are manually converted to a set prior to said operations. The `six.moves` module is deprecated in favor of the `builtins` module, and comprehensions are also used wherever possible (`set`, `list`, and `dict`) in order to avoid having to instantiate types using the builtin. Some Python3-incompatible operators are also fixed such as replacing the division operator (`/`) with the integer division operator (`//`).

This PR is the fourth part of the fix for issue #76, and is dependant on PR #82. 