### PR TITLE
Re-implemented a number of wrappers and refactored the tag-parsing trie in order to be compatible with Python3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ following to list all the functions in your database:
 Or to iterate through all the functions in the database, you can try:
 
     > for ea in database.functions():
-          print hex(ea)
+          print(hex(ea))
 
 Please refer to the documentation for more details on what this plugin makes
 available to you.
@@ -109,7 +109,7 @@ project.
 
 ## Thanks
 
-Thanks to a number of anonymous and non-anonymous people whom have helped the
-development of this plugin over the years.
+Thanks to a number of anonymous and non-anonymous people whom have helped with
+the development of this plugin over all of these years.
 
 [logo]: http://arizvisa.github.io/ida-minsc/_images/hamster.svg

--- a/app/quicktime.py
+++ b/app/quicktime.py
@@ -14,7 +14,7 @@ def nextMnemonic(ea, mnem, maxaddr=0xc0*0x1000000):
 
 def prevMnemonic(ea, mnem, minaddr=0):
     res = idc.print_insn_mnem(ea)
-    #print "%x -> %s"% (ea, res)
+    #print("%x -> %s"% (ea, res))
     if res == "": return idc.BADADDR
     if res == mnem: return ea
     return prevMnemonic( idc.prev_head(ea, minaddr), mnem, minaddr )
@@ -44,8 +44,8 @@ def resolveDispatcher(code):
     if majorFlag != 0:
         return majorAddress + (minor*0x10)
 
-    #print "%x"% getMinorDispatchTableAddress(majorAddress)
-    #print "resolved by 0x%x(%x)"% (majorAddress, minor)
+    #print("%x"% getMinorDispatchTableAddress(majorAddress))
+    #print("resolved by 0x%x(%x)"% (majorAddress, minor))
     return majorAddress
 
 def getDispatchCode(ea):
@@ -74,7 +74,7 @@ def nameDispatch(address):
         start, end = function.range(address)
 
     except ValueError:
-        print '%x making a function'% address
+        print('%x making a function'% address)
         function.make(address)
         start, end = function.range(address)
 
@@ -82,7 +82,7 @@ def nameDispatch(address):
         ea = FindLastAssignment(address, 'eax')
         code = getDispatchCode(ea)
     except ValueError:
-        print '%08x - Unable to find dispatch code'% address
+        print('%08x - Unable to find dispatch code'% address)
         return
 
     ofs = database.getoffset(start)

--- a/base/_comment.py
+++ b/base/_comment.py
@@ -59,7 +59,7 @@ that is prefixed with a backslash.
 
 import functools, operator, itertools, types
 import collections, heapq, string
-import six, logging
+import sys, six, logging
 
 import internal, idaapi
 import codecs
@@ -227,88 +227,148 @@ class _float(default):
     def encode(cls, instance):
         return "float({:f})".format(instance)
 
-@cache.register(str)
-class _str(default):
-    """
-    This encoder/decoder actually supports both ``unicode`` and regular
-    ``str`` due to the ``type`` method checking both string types. Also,
-    we use this class as a superclass for ``_unicode`` so that any kind
-    of string will be encoded into a unicode string which will be
-    converted into UTF8 when written into IDA.
-    """
+if sys.version_info.major < 3:
+    @cache.register(str)
+    class _str(default):
+        """
+        This encoder/decoder actually supports both ``unicode`` and regular
+        ``str`` due to the ``type`` method checking both string types. Also,
+        we use this class as a superclass for ``_unicode`` so that any kind
+        of string will be encoded into a unicode string which will be
+        converted into UTF8 when written into IDA.
+        """
 
-    @classmethod
-    def type(cls, instance):
-        return isinstance(instance, six.string_types)
+        @classmethod
+        def type(cls, instance):
+            return isinstance(instance, six.string_types)
 
-    @classmethod
-    def _unescape(cls, iterable):
-        '''Invert the utils.character.unescape coroutine into a generator.'''
-        state = internal.interface.collect_t(list, lambda agg, ch: agg + [ch])
-        unescape = internal.utils.character.unescape(state); next(unescape)
+        @classmethod
+        def _unescape(cls, iterable):
+            '''Invert the utils.character.unescape coroutine into a generator.'''
+            state = internal.interface.collect_t(list, lambda agg, ch: agg + [ch])
+            unescape = internal.utils.character.unescape(state); next(unescape)
 
-        # iterate through each character in the string
-        for ch in iterable:
-            unescape.send(ch)
+            # iterate through each character in the string
+            for ch in iterable:
+                unescape.send(ch)
 
-            # iterate through the results and yield them to the caller
-            for ch in state.get():
-                yield ch
+                # iterate through the results and yield them to the caller
+                for ch in state.get():
+                    yield ch
 
-            # now we can start over
-            state.reset()
-        return
+                # now we can start over
+                state.reset()
+            return
 
-    @classmethod
-    def _escape(cls, iterable):
-        '''Invert the utils.character.escape coroutine into a generator.'''
-        state = internal.interface.collect_t(list, lambda agg, ch: agg + [ch])
-        escape = internal.utils.character.escape(state); next(escape)
+        @classmethod
+        def _escape(cls, iterable):
+            '''Invert the utils.character.escape coroutine into a generator.'''
+            state = internal.interface.collect_t(list, lambda agg, ch: agg + [ch])
+            escape = internal.utils.character.escape(state); next(escape)
 
-        # iterate through each character in the string
-        for ch in iterable:
-            escape.send(ch)
+            # iterate through each character in the string
+            for ch in iterable:
+                escape.send(ch)
 
-            # iterate through the results and yield them to the caller
-            for ch in state.get():
-                yield ch
+                # iterate through the results and yield them to the caller
+                for ch in state.get():
+                    yield ch
 
-            # empty our state and start over
-            state.reset()
-        return
+                # empty our state and start over
+                state.reset()
+            return
 
-    @classmethod
-    def decode(cls, data):
-        res = data if isinstance(data, unicode) else data.decode('utf8')
-        iterable = (ch for ch in res.lstrip())
-        return unicode().join(cls._unescape(iterable))
+        @classmethod
+        def decode(cls, data):
+            res = data if isinstance(data, unicode) else data.decode('utf8')
+            iterable = (ch for ch in res.lstrip())
+            return unicode().join(cls._unescape(iterable))
 
-    @classmethod
-    def encode(cls, instance):
-        iterable = (item for item in instance)
-        res = cls._escape(iterable)
-        return unicode().join(res)
+        @classmethod
+        def encode(cls, instance):
+            iterable = (item for item in instance)
+            res = cls._escape(iterable)
+            return unicode().join(res)
 
-@cache.register(unicode, pattern.star(' \t'), 'u', "'\"")
-class _unicode(_str):
-    """
-    This encoder/decoder really just a wrapper around the ``_str``
-    class. Its encoder will simply escape the string in the exact
-    same way as ``_str``. We register a pattern for it so that we
-    can decode unicode strings encoded in their older format. Due
-    to the older format requiring unicode strings to begin with
-    the "u'" prefix, we can simply eval it in order to decode
-    back to a unicode string.
-    """
+    @cache.register(unicode, pattern.star(' \t'), 'u', "'\"")
+    class _unicode(_str):
+        """
+        This encoder/decoder really just a wrapper around the ``_str``
+        class. Its encoder will simply escape the string in the exact
+        same way as ``_str``. We register a pattern for it so that we
+        can decode unicode strings encoded in their older format. Due
+        to the older format requiring unicode strings to begin with
+        the "u'" prefix, we can simply eval it in order to decode
+        back to a unicode string.
+        """
 
-    @classmethod
-    def type(cls, instance):
-        return isinstance(instance, unicode)
+        @classmethod
+        def type(cls, instance):
+            return isinstance(instance, unicode)
 
-    @classmethod
-    def decode(cls, data):
-        logging.warning(u"{:s}.decode({!s}) : Decoding a unicode string that was encoded using the old format.".format('.'.join([__name__, cls.__name__]), internal.utils.string.repr(data)))
-        return eval(data)
+        @classmethod
+        def decode(cls, data):
+            logging.warning(u"{:s}.decode({!s}) : Decoding a unicode string that was encoded using the old format.".format('.'.join([__name__, cls.__name__]), internal.utils.string.repr(data)))
+            return eval(data)
+
+else:
+    @cache.register(bytes)
+    class _bytes(default):
+        @classmethod
+        def type(cls, instance):
+            return isinstance(instance, bytes)
+
+    @cache.register(str)
+    class _str(default):
+        @classmethod
+        def type(cls, instance):
+            return isinstance(instance, six.string_types)
+
+        @classmethod
+        def _unescape(cls, iterable):
+            '''Invert the utils.character.unescape coroutine into a generator.'''
+            state = internal.interface.collect_t(list, lambda agg, ch: agg + [ch])
+            unescape = internal.utils.character.unescape(state); next(unescape)
+
+            # iterate through each character in the string
+            for ch in iterable:
+                unescape.send(ch)
+
+                # iterate through the results and yield them to the caller
+                for ch in state.get():
+                    yield ch
+
+                # now we can start over
+                state.reset()
+            return
+
+        @classmethod
+        def _escape(cls, iterable):
+            '''Invert the utils.character.escape coroutine into a generator.'''
+            state = internal.interface.collect_t(list, lambda agg, ch: agg + [ch])
+            escape = internal.utils.character.escape(state); next(escape)
+
+            # iterate through each character in the string
+            for ch in iterable:
+                escape.send(ch)
+
+                # iterate through the results and yield them to the caller
+                for ch in state.get():
+                    yield ch
+
+                # empty our state and start over
+                state.reset()
+            return
+
+        @classmethod
+        def decode(cls, data):
+            res = data if isinstance(data, unicode) else data.decode('utf8')
+            return str().join(cls._unescape(iter(res.lstrip())))
+
+        @classmethod
+        def encode(cls, instance):
+            res = cls._escape(iter(instance))
+            return str().join(res)
 
 @cache.register(dict, pattern.star(' \t'), '{')
 class _dict(default):

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -333,7 +333,7 @@ class prioritybase(object):
 
         # add the callable to our priority queue
         res = self.__cache__[target]
-        heapq.heappush(self.__cache__[target], (priority, callable))
+        heapq.heappush(self.__cache__[target], internal.utils.priority_tuple(priority, callable))
 
         # preserve a backtrace so we can track where our callable is at
         self.__traceback[(target, callable)] = traceback.extract_stack()[:-1]
@@ -363,7 +363,7 @@ class prioritybase(object):
         # If we aggregated some items, then replace our cache with everything
         # except for the item the user discarded.
         if state:
-            self.__cache__[target][:] = state
+            self.__cache__[target][:] = [internal.utils.priority_tuple(*item) for item in state]
 
         # Otherwise we found nothing and we can remove the entire target
         # from our cache.
@@ -531,7 +531,7 @@ class priorityhook(prioritybase):
 
         # unhook, assign our new method, and then re-hook
         with self.__context__():
-            method = types.MethodType(closure, self.object, self.__type__)
+            method = internal.utils.pycompat.method.new(closure, self.object, self.__type__)
             setattr(self.object, name, method)
         return True
 
@@ -543,7 +543,7 @@ class priorityhook(prioritybase):
         if not hasattr(self.object, name):
             cls, method = self.__class__, '.'.join([self.object.__class__.__name__, name])
             raise NameError("{:s}.disconnect({!r}, {!s}) : Unable to disconnect from the specified hook ({:s}).".format('.'.join([__name__, cls.__name__]), name, callable, method))
-        method = types.MethodType(closure, self.object, self.__type__)
+        method = internal.utils.pycompat.method.new(closure, self.object, self.__type__)
         setattr(self.object, name, method)
         return True
 

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -665,8 +665,8 @@ class character(object):
         # whitespace characters as a set
         whitespace = { ch for ch in _string.whitespace }
 
-        # printable characters as a set
-        printable = { ch for ch in _string.printable } - whitespace
+        # printable characters as a set (spaces are the only whitespace that we consider as printable)
+        printable = { ch for ch in _string.printable } - whitespace | {u' '}
 
         # hexadecimal digits as a lookup
         hexadecimal = { ch : i for i, ch in enumerate(_string.hexdigits[:0x10]) }
@@ -743,7 +743,7 @@ class character(object):
                 result.send(ch)
 
             # check if character is printable (ascii)
-            elif isinstance(ch, str) and cls.asciiQ(ch):
+            elif isinstance(ch, six.string_types) and cls.asciiQ(ch):
                 result.send(ch)
 
             # check if character is a single-byte ascii

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -902,7 +902,7 @@ class string(object):
     }
 
     @classmethod
-    def escape(cls, string, quote=''):
+    def escape(cls, string, quote=u''):
         """Escape the characters in `string` specified by `quote`.
 
         Handles both unicode and ascii. Defaults to escaping only
@@ -946,15 +946,19 @@ class string(object):
 
         # Python2 string types (str/bytes and unicode)
         if isinstance(item, six.string_types) and sys.version_info.major < 3:
-            res = cls.escape(item, '\'')
+            res = cls.escape(item.decode('latin1') if isinstance(item, bytes) else item, u'\'')
             if all(ord(ch) < 0x100 for ch in item):
-                return "'{:s}'".format(res)
+                return u"'{:s}'".format(res)
             return u"u'{:s}'".format(res)
 
-        # Python3 string types (bytes and str)
-        elif isinstance(item, (six.string_types, bytes)):
-            res = cls.escape(item, '\'')
-            return u"b'{:s}'".format(res) if isinstance(item, bytes) else u"'{:s}'".format(res)
+        # Python3 string types (str and bytes)
+        elif isinstance(item, six.string_types):
+            res = cls.escape(item, u'\'')
+            return u"'{:s}'".format(res)
+
+        elif isinstance(item, bytes):
+            res = cls.escape(item.decode('latin1'), u'\'')
+            return u"b'{:s}'".format(res)
 
         elif isinstance(item, tuple):
             res = map(cls.repr, item)

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -820,7 +820,11 @@ class wrap(object):
     CO_FUTURE_BARRY_AS_BDFL     = 0x40000
     CO_FUTURE_GENERATOR_STOP    = 0x80000
 
-    import opcode, compiler.consts as consts
+    import opcode
+    if sys.version_info.major < 3:
+        import compiler.consts as consts
+    else:
+        import inspect as consts
 
     @classmethod
     def co_assemble(cls, operation, operand=None):

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -890,7 +890,7 @@ class string(object):
     @classmethod
     def passthrough(cls, string):
         '''Handle all strings both from IDA and to IDA transparently.'''
-        return None if string is None else string.decode('utf8') if isinstance(string, bytes) else string
+        return None if string is None else string
 
     of = of_2x if sys.version_info.major < 3 else passthrough
     to = to_2x if sys.version_info.major < 3 else passthrough

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -705,9 +705,10 @@ class character(object):
     @classmethod
     def to_hex(cls, integer):
         '''Given an integer, return the hex digit that it represents.'''
-        if integer >= 0 and integer < 0x10:
-            return six.unichr(integer + 0x30) if integer < 10 else six.unichr(integer + 0x57)
-        raise ValueError
+        inverse = { digit : char for char, digit in cls.const.hexadecimal.items() }
+        if integer in inverse:
+            return operator.getitem(inverse, integer)
+        raise ValueError(integer)
 
     @classmethod
     def of_hex(cls, digit):

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -1275,16 +1275,28 @@ def transform(translate, *names):
         # convert any positional arguments
         res = ()
         for value, argname in zip(rargs, argnames):
-            res += (translate(value) if argname in names else value),
+            try:
+                res += (translate(value) if argname in names else value),
+            except Exception as E:
+                cls = E.__class__
+                raise cls("{!s}: Exception raised while transforming parameter `{:s}` with value {!r}".format('.'.join([f.__module__, f.__name__]), argname, value))
 
         # get the rest
         for value in rargs[len(res):]:
-            res += (translate(value) if wildname in names else value,)
+            try:
+                res += (translate(value) if wildname in names else value,)
+            except Exception as E:
+                cls = E.__class__
+                raise cls("{!s}: Exception raised while transforming parameters `{:s}` with value {!r}".format('.'.join([f.__module__, f.__name__]), wildname, value))
 
         # convert any keywords arguments
         kwds = {k : v for k, v in rkwds.items()}
         for argname in {item for item in rkwds.keys()} & names:
-            kwds[argname] = translate(kwds[argname])
+            try:
+                kwds[argname] = translate(kwds[argname])
+            except Exception as E:
+                cls = E.__class__
+                raise cls("{!s}: Exception raised while transforming parameter `{:s}` with value {!r}".format('.'.join([f.__module__, f.__name__]), argname, kwds[argname]))
         return F(*res, **kwds)
 
     # decorater that wraps the function `F` with `wrapper`.

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -1198,12 +1198,12 @@ class wrap(object):
     # Python3 implementation of the assemble function which will take a callable, pass it as the first
     # parameter to some kind of wrapper (callable) whilst preserving any arguments/names that were called.
     @classmethod
-    def assemble_3x(cls, function, wrapper, bound=False):
+    def assemble_38x(cls, function, wrapper, bound=False):
         """Assemble a ``types.CodeType`` that will execute `wrapper` with `F` as its first parameter.
 
         If `bound` is ``True``, then assume that the first parameter for `F` represents the instance it's bound to.
         """
-        F, C, S = (cls.extract(item) for item in [function, wrapper, cls.assemble_3x])
+        F, C, S = (cls.extract(item) for item in [function, wrapper, cls.assemble_38x])
         Fc, Cc, Sc = (pycompat.function.code(item) for item in [F, C, S])
         Nvarargs, Nvarkwds = 1 if cls.co_varargsQ(Fc) else 0, 1 if cls.co_varkeywordsQ(Fc) else 0
 
@@ -1298,10 +1298,112 @@ class wrap(object):
 
         return res
 
+    @classmethod
+    def assemble_39x(cls, function, wrapper, bound=False):
+        """Assemble a ``types.CodeType`` that will execute `wrapper` with `F` as its first parameter.
+
+        If `bound` is ``True``, then assume that the first parameter for `F` represents the instance it's bound to.
+        """
+        F, C, S = (cls.extract(item) for item in [function, wrapper, cls.assemble_39x])
+        Fc, Cc, Sc = (pycompat.function.code(item) for item in [F, C, S])
+        Nvarargs, Nvarkwds = 1 if cls.co_varargsQ(Fc) else 0, 1 if cls.co_varkeywordsQ(Fc) else 0
+
+        ### build the namespaces that we'll use.
+
+        # first we'll build the externals that get passed to the wrapper.
+        Sargs = ('F', 'wrapper')
+        Svals = (f if callable(f) else fo for f, fo in [(function, F), (wrapper, C)])
+
+        # rip out the arguments from our target `F`.
+        varnames, argcount = pycompat.code.varnames(Fc), pycompat.code.argcount(Fc)
+        Fargs, Fdefaults = varnames[:argcount], pycompat.function.defaults(F)
+        Fvarargs, Fvarkwds = varnames[argcount : argcount + Nvarargs], varnames[argcount + Nvarargs : argcount + Nvarargs + Nvarkwds]
+
+        # combine them into tuples for looking up variables.
+        co_names, co_varnames = Sargs[:], Fargs[:] + Fvarargs[:] + Fvarkwds[:]
+
+        ## free variables (that get passed to `C`).
+        co_freevars = Sargs[:2]
+
+        ## constants for code type (which consist of just the self-doc).
+        co_consts = (pycompat.function.documentation(F),)
+
+        ## flags for the code type.
+        co_flags = cls.CO_NESTED | cls.CO_OPTIMIZED | cls.CO_NEWLOCALS
+        co_flags |= cls.CO_VARARGS if Nvarargs > 0 else 0
+        co_flags |= cls.CO_VARKEYWORDS if Nvarkwds > 0 else 0
+
+        ### figure out some things for assembling the bytecode.
+        code_, co_stacksize = [], 0
+        asm = code_.append
+
+        # first we push the callable that we need to call to wrap our function.
+        asm(cls.co_assemble('LOAD_DEREF', co_freevars.index('wrapper')))
+        co_stacksize += 1
+
+        ## now we need to pack all of our parameters into a tuple starting with our
+        ## `F` parameter which contains the function taht's being wrapped.
+        asm(cls.co_assemble('LOAD_DEREF', co_freevars.index('F')))
+        co_stacksize += 1
+
+        # now we can include all of the original arguments (cropped by +1 if bound).
+        for item in Fargs[int(bound):]:
+            asm(cls.co_assemble('LOAD_FAST', co_varnames.index(item)))
+            co_stacksize += 1
+
+        # then we can finally pack it into a list
+        asm(cls.co_assemble('BUILD_LIST', 1 + len(Fargs[int(bound):])))
+
+        ## now we need to pack all wildcard arguments...
+        for item in Fvarargs:
+            asm(cls.co_assemble('LOAD_FAST', co_varnames.index(item)))
+            asm(cls.co_assemble('LIST_EXTEND', 1))
+        co_stacksize = max(1 + len(Fvarargs), co_stacksize)
+
+        # ...and convert it into a tuple
+        asm(cls.co_assemble('LIST_TO_TUPLE'))
+
+        ## now we need to pack all kw arguments...
+        asm(cls.co_assemble('BUILD_MAP', 0))
+
+        for item in Fvarkwds:
+            asm(cls.co_assemble('LOAD_FAST', co_varnames.index(item)))
+            asm(cls.co_assemble('DICT_MERGE', 1))
+        co_stacksize = max(len(Fvarkwds), co_stacksize)
+
+        ## finally we have our arguments, and can now assemble our call...
+        asm(cls.co_assemble('CALL_FUNCTION_EX', 1))
+
+        # ...and then return its value.
+        asm(cls.co_assemble('RETURN_VALUE'))
+
+        ## next we'll construct the code type using our new opcodes.
+
+        # combine our opcodes into a single code string.
+        co_code = bytes().join(code_)
+
+        # consruct the new code object with all our fields.
+        cargs = pycompat.code.cons( \
+                    len(Fargs), len(co_names) + len(co_varnames) + len(co_freevars), \
+                    co_stacksize, co_flags, co_code, \
+                    co_consts, co_names, co_varnames, \
+                    Fc.co_filename, Fc.co_name, Fc.co_firstlineno, \
+                    bytes(), co_freevars, ()
+                )
+
+        func_code = pycompat.code.new(cargs)
+
+        ## finally take our code object, and put it back into a function/callable.
+        res = pycompat.function.new(func_code, pycompat.function.globals(F), pycompat.function.name(F), pycompat.function.defaults(F), cls.cell(*Svals))
+        pycompat.function.set_name(res, pycompat.function.name(F)),
+        pycompat.function.set_documentation(res, pycompat.function.documentation(F))
+
+        return res
+
     def __new__(cls, callable, wrapper):
         '''Return a function similar to `callable` that calls `wrapper` with `callable` as the first argument.'''
         cons, f = cls.constructor(callable), cls.extract(callable)
-        Fassemble = cls.assemble_2x if sys.version_info.major < 3 else cls.assemble_3x
+        Fassemble = cls.assemble_2x if sys.version_info.major < 3 else cls.assemble_38x if sys.version_info.minor < 9 else cls.assemble_39x
 
         # create a wrapper for the function that'll execute `callable` with the function as its first argument, and the rest with any args
         res = Fassemble(callable, wrapper, bound=isinstance(callable, (classmethod, types.MethodType)))

--- a/base/database.py
+++ b/base/database.py
@@ -3159,9 +3159,9 @@ class type(object):
 
     Some examples of using this namespace can be::
 
-        > print database.type.size(ea)
-        > print database.type.is_initialized(ea)
-        > print database.type.is_data(ea)
+        > print( database.type.size(ea) )
+        > print( database.type.is_initialized(ea) )
+        > print( database.type.is_data(ea) )
         > length = database.t.array.length(ea)
         > st = database.t.structure(ea)
 
@@ -3606,10 +3606,10 @@ class type(object):
         Some examples of using this namespace can be::
 
             > type, length = database.t.array()
-            > print database.t.array.size(ea)
-            > print database.t.array.member(ea)
-            > print database.t.array.element(ea)
-            > print database.t.array.length(ea)
+            > print( database.t.array.size(ea) )
+            > print( database.t.array.member(ea) )
+            > print( database.t.array.element(ea) )
+            > print( database.t.array.length(ea) )
 
         """
         @utils.multicase()
@@ -3700,7 +3700,7 @@ class type(object):
         Some of the ways to use this namespace are::
 
             > st = database.t.struct()
-            > print database.t.struct.size()
+            > print( database.t.struct.size() )
             > st = structure.by(database.t.id(ea))
 
         """
@@ -3828,7 +3828,7 @@ class xref(object):
 
     Some ways to utilize this namespace can be::
 
-        > print database.x.up()
+        > print( database.x.up() )
         > for ea in database.x.down(): ...
         > for ea in database.x.cu(ea): ...
         > ok = database.x.add_code(ea, target)
@@ -6167,7 +6167,7 @@ class get(object):
         This namespace can be used as in the following example::
 
             > sw = database.get.switch(ea)
-            > print sw
+            > print( sw )
 
         """
         @classmethod

--- a/base/database.py
+++ b/base/database.py
@@ -5881,7 +5881,7 @@ class get(object):
             # from the database. Then we can use the data to initialize the _array
             # that we're going to return to the user.
             data = read(ea, count * cb)
-            res.fromstring(data)
+            res.fromstring(data) if sys.version_info.major < 3 else res.frombytes(data)
 
             # Validate the _array's length so that we can warn the user if it's wrong.
             if len(res) != count:
@@ -6080,11 +6080,12 @@ class get(object):
             res = cls.unsigned(ea, shift)
             length.setdefault('length', res)
 
-        # Now we can read the string..
-        res = cls.array(ea + shift, **length).tostring()
+        # Now we can read the string, and convert it to some bytes to decode
+        res = cls.array(ea + shift, **length)
+        data = res.tostring() if sys.version_info.major < 3 else res.tobytes()
 
         # ..and then process it.
-        return fterminate(fdecode(res))
+        return fterminate(fdecode(data))
     @utils.multicase()
     @classmethod
     def structure(cls):

--- a/base/function.py
+++ b/base/function.py
@@ -948,11 +948,11 @@ class block(object):
         > B = function.block(ea)
         > bid = function.block.id()
         > c = function.block.color(ea, rgb)
-        > print function.block.before(ea)
-        > for ea in function.block.iterate(): print database.disasm(ea)
+        > print( function.block.before(ea) )
+        > for ea in function.block.iterate(): print( database.disasm(ea) )
         > for ea, op, st in function.block.register('eax', read=1): ...
-        > print function.block.read().encode('hex')
-        > print function.block.disasm(ea)
+        > print( function.block.read().encode('hex') )
+        > print( function.block.disasm(ea) )
 
     """
     @utils.multicase()
@@ -1438,8 +1438,8 @@ class frame(object):
 
     Some ways of using this can be::
 
-        > print function.frame()
-        > print hex(function.frame.id(ea))
+        > print( function.frame() )
+        > print( hex(function.frame.id(ea)) )
         > sp = function.frame.delta(ea)
 
     """
@@ -1529,8 +1529,8 @@ class frame(object):
 
         Some ways of using this are::
 
-            > print function.frame.args(f)
-            > print function.frame.args.size(ea)
+            > print( function.frame.args(f) )
+            > print( function.frame.args.size(ea) )
 
         """
 
@@ -1602,7 +1602,7 @@ class frame(object):
 
         Some ways to get this information can be::
 
-            > print function.frame.lvars.size()
+            > print( function.frame.lvars.size() )
 
         """
         @utils.multicase()
@@ -1644,7 +1644,7 @@ class frame(object):
 
         An example of using this namespace::
 
-            > print function.frame.regs.size(ea)
+            > print( function.frame.regs.size(ea) )
 
         """
 
@@ -2023,7 +2023,7 @@ class type(object):
 
     Some simple ways of getting information about a function::
 
-        > print function.type.has_noframe()
+        > print( function.type.has_noframe() )
         > for ea in filter(function.type.is_library, database.functions()): ...
 
     """

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -1251,10 +1251,10 @@ class type(object):
 
     Some examples of using this namespace are::
 
-        > print instruction.type.is_return(ea)
-        > print instruction.type.is_jxx(ea)
-        > print instruction.type.is_call(ea)
-        > print instruction.type.is_branch(ea)
+        > print( instruction.type.is_return(ea) )
+        > print( instruction.type.is_jxx(ea) )
+        > print( instruction.type.is_call(ea) )
+        > print( instruction.type.is_branch(ea) )
 
     """
     @utils.multicase()

--- a/base/structure.py
+++ b/base/structure.py
@@ -1427,7 +1427,7 @@ class members_t(object):
         '''Display all the fields within the specified structure.'''
         res = []
         mn, ms, mti = 0, 0, 0
-        for i in six.moves.range(len(self)):
+        for i in range(len(self)):
             m = self[i]
             name, t, ti, ofs, size, comment, tag = m.name, m.type, m.typeinfo, m.offset, m.size, m.comment, m.tag()
             res.append((i, name, t, ti, ofs, size, comment or '', tag))

--- a/custom/tags.py
+++ b/custom/tags.py
@@ -246,9 +246,9 @@ class apply(object):
     before actually writing them back into the database.
     """
 
-    def __new__(cls, (Globals, Contents, Frames), **tagmap):
-        '''Apply the tags in the argument `(Globals, Contents, Frames)` back into the database.'''
-        res = Globals, Contents, Frames
+    def __new__(cls, Globals_Contents_Frames, **tagmap):
+        '''Apply the tags in the argument `(Globals, Contents, Frames)` from the `Globals_Contents_Frames` tuple back into the database.'''
+        res = Globals, Contents, Frames = Globals_Contents_Frames
         return cls.everything(res, **tagmap)
 
     ## applying the content to a function
@@ -374,9 +374,10 @@ class apply(object):
 
     ## apply everything to the entire database
     @classmethod
-    def everything(cls, (Globals, Contents, Frames), **tagmap):
-        '''Apply the tags in the argument `(Globals, Contents, Frames)` back into the database.'''
+    def everything(cls, Globals_Contents_Frames, **tagmap):
+        '''Apply the tags in the argument `(Globals, Contents, Frames)` from the `Globals_Contents_Frames` tuple back into the database.'''
         global apply
+        Globals, Contents, Frames = Globals_Contents_Frames
 
         ## convert a sorted list keyed by an address into something that updates ida's navigation pointer
         def update_navigation(xs, setter):

--- a/idapythonrc.py
+++ b/idapythonrc.py
@@ -136,13 +136,16 @@ class internal_submodule(internal_api):
         module.__doc__ = '\n'.join("{:s} -- {:s}".format(name, path) for name, path in sorted(cache.items()))
 
         # Load each module composing the api, and attach it to the returned submodule.
-        for name, path in cache.items():
+        stack = [item for item in cache.items()]
+        while stack:
+            name, path = stack.pop(0)
             try:
                 res = self.new_api(name, path)
                 modulename = '.'.join([res.__package__, name])
 
             except Exception:
-                __import__('logging').warning("{:s} : Unable to import module {:s} from {!s}".format(self.__name__, name, path), exc_info=True)
+                __import__('logging').info("{:s} : Error trying to import module {:s} from {!s}. Queuing it until later.".format(self.__name__, name, path), exc_info=True)
+                stack.append((name, path))
 
             else:
                 setattr(module, name, res)

--- a/misc/tools.py
+++ b/misc/tools.py
@@ -27,8 +27,8 @@ def map(F, **kwargs):
     `(address, **kwargs)` or a `(index, address, **kwargs)`. Any
     keyword arguments are passed to `F` unmodified.
     """
-    f1 = lambda (idx, ea), **kwargs: F(ea, **kwargs)
-    f2 = lambda (idx, ea), **kwargs: F(idx, ea, **kwargs)
+    f1 = lambda idx, ea, **kwargs: F(ea, **kwargs)
+    f2 = lambda idx, ea, **kwargs: F(idx, ea, **kwargs)
     f = f1 if F.func_code.co_argcount == 1 else f2
 
     result, all = [], database.functions()
@@ -39,7 +39,7 @@ def map(F, **kwargs):
             for i, ea in enumerate(all):
                 ui.navigation.set(ea)
                 six.print_("{:#x}: processing # {:d} of {:d} : {:s}".format(ea, 1 + i, total, func.name(ea)))
-                result.append( f((i, ea), **kwargs) )
+                result.append( f(i, ea, **kwargs) )
         except KeyboardInterrupt:
             six.print_("{:#x}: terminated at # {:d} of {:d} : {:s}".format(ea, 1 + i, total, func.name(ea)))
     return result

--- a/misc/tools.py
+++ b/misc/tools.py
@@ -29,7 +29,9 @@ def map(F, **kwargs):
     """
     f1 = lambda idx, ea, **kwargs: F(ea, **kwargs)
     f2 = lambda idx, ea, **kwargs: F(idx, ea, **kwargs)
-    f = f1 if F.func_code.co_argcount == 1 else f2
+    Ff = internal.utils.pycompat.method.function(F) if isinstance(F, types.MethodType) else F
+    Fc = internal.utils.pycompat.function.code(Ff)
+    f = f1 if internal.utils.pycompat.code.argcount(Fc) == 1 else f2
 
     result, all = [], database.functions()
     total = len(all)

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -696,13 +696,14 @@ class widget(object):
     """
     This namespace is for selecting a specific or particular widget.
     """
-    def __new__(self, (x, y)):
-        '''Return the widget at the specified `x` and `y` coordinate.'''
-        res = (x, y)
+    def __new__(self, xy):
+        '''Return the widget at the specified (`x`, `y`) coordinate within the `xy` tuple.'''
+        res = x, y = xy
         return cls.at(res)
     @classmethod
-    def at(cls, (x, y)):
-        '''Return the widget at the specified `x` and `y` coordinate.'''
+    def at(cls, xy):
+        '''Return the widget at the specified (`x`, `y`) coordinate within the `xy` tuple.'''
+        res = x, y = xy
         global application
         q = application()
         return q.widgetAt(x, y)


### PR DESCRIPTION
Python3 does a number of things to break compatibility with Python2. Due to this, there's a number of capabilities in this plugin that are broken when trying to run them in Python3. Some of these things are that the the parameters used for constructing code, function, and method types are different. Modules now include a `ModuleSpec` under the `module.__loader__` property. Parameters can't be unpacked in function definitions, and tuples can't be compared anymore. Other than things like `int` and `long` being consolidated into a single type, and `bytes` and `str` being considered as exclusive types (deprecating `unicode`) there were a few changes to the opcodes used by Python bytecode.

This PR fixes these issues in two major parts. The first part is to implement a compatibility class in `internal.utils`. This compatibility class allows one to interact with both function and code types in a portable manner between regardless of whether Python2 or Python3 is being used. The other part was to refactor the trie used in `internal.comment` to use different encoders/decoders depending on whether Python2 or Python3 is being used. This might introduce some backwards-compatibility issues as unicode strings were being trusted to Python's `eval` and `repr` operators.

The other minor fixes that were done include things like manually unpacking tuple-parameters in the implementation rather than the definition, and implementing a wrapper around the tuple that's used by the multicase logic in the `internal.interface` module. This wrapper is necessary for the `heapq` that's used due to Python3 not being able to compare tuples anymore. Previously, the priority was passed as the first element in the `heapq` and thus would be used to identify which function case to dispatch to. The new implementation will now simply wrap the tuple, and if the comparison methods are called on the tuple then the implementation will compare the priority stored in the first element of both tuples.

Unfortunately some pythonic types ended up being removed as a result of Python3. Types composed of `long`, `unicode`, or `unichr` are now non-existent and thus the user will need to explicitly specify their element size as a tuple.

This PR is the final part (5th) of the fix for #76, and is dependant on PR #83.