### PR TITLE
Replace the types used in the `internal.netnode` module with types that are common between both Python2 and Python3.

### DIFF
--- a/base/_comment.py
+++ b/base/_comment.py
@@ -699,9 +699,10 @@ class contents(tagging):
         if key is None:
             raise internal.exceptions.FunctionNotFoundError(u"{:s}._read_header({!r}, {:#x}) : Unable to locate a function for target ({!r}) at {:#x}.".format('.'.join([__name__, cls.__name__]), target, ea, key, ea))
 
-        encdata = internal.netnode.sup.get(node, key)
-        if encdata is None:
+        view = internal.netnode.sup.get(node, key, type=memoryview)
+        if view is None:
             return None
+        encdata = view.tobytes()
 
         try:
             data, sz = cls.codec.decode(encdata)
@@ -850,7 +851,8 @@ class contents(tagging):
         '''Yield each address and names for all of the contents tags in the database according to what is written into the tagging supval.'''
         node = tagging.node()
         for ea in internal.netnode.sup.fiter(node):
-            encdata = internal.netnode.sup.get(node, ea)
+            view = internal.netnode.sup.get(node, ea, type=memoryview)
+            encdata = view.tobytes()
             data, sz = cls.codec.decode(encdata)
             if len(encdata) != sz:
                 logging.warn(u"{:s}.iterate() : Error while decoding the tag names out of the sup cache for address {:#x} due to the length of encoded data not matching the expected size ({:#x}<>{:#x}).".format('.'.join([__name__, cls.__name__]), ea, len(encdata), sz))

--- a/base/function.py
+++ b/base/function.py
@@ -238,9 +238,10 @@ def convention(func):
     The integer returned corresponds to one of the ``idaapi.CM_CC_*`` constants.
     """
     rt, ea = interface.addressOfRuntimeOrStatic(func)
-    sup = internal.netnode.sup.get(ea, 0x3000)
-    if sup is None:
+    view = internal.netnode.sup.get(ea, 0x3000, type=memoryview)
+    if view is None:
         raise E.MissingTypeOrAttribute(u"{:s}.convention({!r}) : Specified function does not contain a prototype declaration.".format(__name__, func))
+    sup = view.tobytes()
     try:
         _, _, cc = interface.node.sup_functype(sup)
     except E.UnsupportedCapability:

--- a/base/structure.py
+++ b/base/structure.py
@@ -1749,7 +1749,8 @@ class member_t(object):
         # now figure out which operand has the structure member applied to it
         res = []
         for ea, _, t in refs:
-            listable = [(idx, internal.netnode.sup.get(ea, 0xf+idx)) for idx in six.moves.range(idaapi.UA_MAXOP) if internal.netnode.sup.get(ea, 0xf+idx) is not None]
+            iterable = ((idx, internal.netnode.sup.get(ea, 0xf + idx, type=memoryview)) for idx in six.moves.range(idaapi.UA_MAXOP) if internal.netnode.sup.get(ea, 0xf + idx) is not None)
+            listable = [(idx, view.tobytes()) for idx, view in iterable]
 
             # check if we found any ops that point directly to this member
             if any(listable):

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -747,8 +747,8 @@ def extra_cmt_changed(ea, line_idx, cmt):
     #      implementation, if we can't distinguish between the old and new extra
     #      comments, then its simply a no-op. this is okay for now...
 
-    oldcmt = internal.netnode.sup.get(ea, line_idx)
-    if oldcmt is not None: oldcmt = oldcmt.rstrip('\0')
+    oldcmt = internal.netnode.sup.get(ea, line_idx, type=memoryview)
+    if oldcmt is not None: oldcmt = oldcmt.tobytes().rstrip(b'\0')
     ctx = internal.comment.contents if idaapi.get_func(ea) else internal.comment.globals
 
     MAX_ITEM_LINES = (idaapi.E_NEXT-idaapi.E_PREV) if idaapi.E_NEXT > idaapi.E_PREV else idaapi.E_PREV-idaapi.E_NEXT


### PR DESCRIPTION
The `internal.netnode` module uses a very particular syntax in order to determine which netnode functions to use when reading or writing to the various netnode types within a database. This syntax is based on using `str`, `int`, and `buffer` in order to determine which function to use and what type it should return.

In Python3, these types have been deprecated and are thus completely missing from its builtins. This is due to Python3 replacing `str` with a new `bytes` type, and then removing `buffer` since it's really just a protocol that an instance is supposed to follow. This means that we'll need to introduce breaking changes to `internal.netnode` if we still want to allow a user to explicitly specify which type to get and set netnodes with.

Previously the `buffer` type was used for determining whether things like `idaapi.netnode.hashstr_buf` would be called, and the `str` type was used to determine whether `idaapi.netnode.valstr` would be called due to the name directly mapping to the api. In Python2, the `str` type is really an alias for `bytes` and so we were previously doing explicit tests for this using `six.string_types` in order to dispatch to the correct byte handler. As the semantics of this are different in Python3, we instead use the `bytes` type as an alias for `buffer`, and fallback to `str` so that we can mirror the semantics of Python2.

It was noticed that some of the netnode api would cull out all the trailing nulls (for strings), or would cull out only the last null (for a buffer). Due to this inconsistency, we now handle both `bytes` and `memoryview` by fetching the entire netnode's value, and then explicitly converting it to the type the user requested. This means that the correct way to guarantee that you set/get the actual bytes at a particular netnode is to now use a `memoryview` object. This type will internally fetch the entire value of a netnode, and then wrap it in a read-only `memoryview`. Then, to get its value it will need to be converted with either `memoryview.tobytes` or `memoryview.tolist`.

This PR fixes issue #85.