### PR TITLE
Added support for keyword parameters to the `interface.bounds_t` constructor, imported it into the root namespace, and improved a number of places where it's used.

### DIFF
--- a/__root__.py
+++ b/__root__.py
@@ -99,7 +99,7 @@ Any = utils.PatternAny()
 del(utils)
 
 # some types that the user might want to compare with
-architecture_t, register_t, symbol_t = (getattr(__import__('internal').interface, item) for item in ['architecture_t', 'register_t', 'symbol_t'])
+architecture_t, register_t, symbol_t, bounds_t = (getattr(__import__('internal').interface, item) for item in ['architecture_t', 'register_t', 'symbol_t', 'bounds_t'])
 ref_t, opref_t = (getattr(__import__('internal').interface, item) for item in ['ref_t', 'opref_t'])
 
 # other miscellaneous modules to expose to the user

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1762,7 +1762,36 @@ class bounds_t(namedtypedtuple):
     _fields = ('left', 'right')
     _types = (six.integer_types, six.integer_types)
 
-    def __new__(cls, *args):
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 2 and not kwargs:
+            return super(bounds_t, cls).__new__(cls, *sorted(args))
+
+        # create a mapping containing our individual fields given with our
+        # arguments. the keyword parameters are given secondary priority to
+        # any argument parameters.
+        fields = {fld : item for fld, item in zip(cls._fields, args)}
+        [ fields.setdefault(fld, kwargs.pop(fld)) for fld in cls._fields if fld in kwargs ]
+
+        # if the size was provided, then we can use it to calculate the
+        # right size of our boundaries.
+        if all(item in fields for item in cls._fields) and 'size' in kwargs:
+            raise TypeError("{!s}() got unexpected keyword argument{:s} {:s}".format(cls.__name__, '' if len(kwargs) == 1 else 's', ', '.join(map("'{!s}'".format, kwargs))))
+
+        elif 'left' in fields and 'size' in kwargs:
+            fields.setdefault('right', fields['left'] + kwargs.pop('size'))
+
+        # at this point, we should have all our boundaries. it kwargs has
+        # anything left in it or any required fields are not defined, then
+        # raise an exception because invalid parameters were passed to us.
+        if len(kwargs):
+            raise TypeError("{!s}() got unexpected keyword argument{:s} {:s}".format(cls.__name__, '' if len(kwargs) == 1 else 's', ', '.join(map("'{!s}'".format, kwargs))))
+        if any(item not in fields for item in cls._fields):
+            available, required = ({item for item in items} for items in [fields, cls._fields])
+            missing = required - available
+            raise TypeError("{!s}() is missing required field{:s} {:s}".format(cls.__name__, '' if len(missing) == 1 else 's', ', '.join(map("'{!s}'".format, (item for item in cls._fields if item in missing)))))
+
+        # now we can use our fields to construct our type properly.
+        args = (fields[item] for item in cls._fields)
         return super(bounds_t, cls).__new__(cls, *sorted(args))
 
     @property
@@ -1777,7 +1806,15 @@ class bounds_t(namedtypedtuple):
         return left <= ea < right if left < right else right <= ea < left
     __contains__ = contains
 
-    def __repr__(self):
+    def __str__(self):
         cls = self.__class__
-        res = ("{!s}={:#x}".format(internal.utils.string.escape(name, ''), value) for name, value in zip(self._fields, self))
-        return "{:s}({:s})".format(cls.__name__, ', '.join(res))
+        items = ("{!s}={:#x}".format(internal.utils.string.escape(name, ''), value) for name, value in zip(self._fields, self))
+        return "{:s}({:s})".format(cls.__name__, ', '.join(items))
+
+    def __unicode__(self):
+        cls = self.__class__
+        items = (u"{!s}={:#x}".format(internal.utils.string.escape(name, ''), value) for name, value in zip(self._fields, self))
+        return u"{:s}({:s})".format(cls.__name__, u', '.join(items))
+
+    def __repr__(self):
+        return u"{!s}".format(self)

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1800,6 +1800,12 @@ class bounds_t(namedtypedtuple):
         left, right = self
         return right - left if left < right else left - right
 
+    def translate(self, offset):
+        '''Return an instance of the class with its boundaries translated by the provided `offset`.'''
+        cls = self.__class__
+        left, right = self
+        return cls(offset + left, offset + right)
+
     def contains(self, ea):
         '''Return if the address `ea` is contained by the ``bounds_t``.'''
         left, right = self

--- a/base/database.py
+++ b/base/database.py
@@ -2119,16 +2119,28 @@ class address(object):
         '''Iterate through all of the addresses defined within `bounds`.'''
         left, right = bounds
         return cls.iterate(left, cls.prev(right))
+    @utils.multicase(bounds=tuple, step=callable)
+    @classmethod
+    def iterate(cls, bounds, step):
+        '''Iterate through all of the addresses defined within `bounds` using the callable `step` to determine the next address.'''
+        left, right = bounds
+        return cls.iterate(left, cls.prev(right), step)
 
     @classmethod
     @utils.multicase(end=six.integer_types)
     def blocks(cls, end):
-        '''Yields the bounds of each block from the current address to `end`.'''
+        '''Yields the boundaries of each block from the current address to `end`.'''
         return cls.blocks(ui.current.address(), end)
+    @classmethod
+    @utils.multicase(bounds=tuple)
+    def blocks(cls, bounds):
+        '''Yields the boundaries of each block within the specified `bounds`.'''
+        left, right = bounds
+        return cls.blocks(left, right)
     @classmethod
     @utils.multicase(start=six.integer_types, end=six.integer_types)
     def blocks(cls, start, end):
-        '''Yields the bounds of each block between the addresses `start` and `end`.'''
+        '''Yields the boundaries of each block between the addresses `start` and `end`.'''
         block, _ = start, end = interface.address.head(start), address.tail(end) + 1
         for ea in cls.iterate(start, end):
             nextea = cls.next(ea)

--- a/base/database.py
+++ b/base/database.py
@@ -602,7 +602,7 @@ def read(ea, size):
     get_bytes = idaapi.get_many_bytes if idaapi.__version__ < 7.0 else idaapi.get_bytes
     start, end = interface.address.within(ea, ea + size)
     return get_bytes(ea, end - start) or b''
-@utils.multicase(bounds=interface.bounds_t)
+@utils.multicase(bounds=tuple)
 def read(bounds):
     '''Return the bytes within the specified `bounds`.'''
     get_bytes = idaapi.get_many_bytes if idaapi.__version__ < 7.0 else idaapi.get_bytes
@@ -2113,7 +2113,7 @@ class address(object):
                 yield res
                 res = step(res)
         except E.OutOfBoundsError: pass
-    @utils.multicase(bounds=interface.bounds_t)
+    @utils.multicase(bounds=tuple)
     @classmethod
     def iterate(cls, bounds):
         '''Iterate through all of the addresses defined within `bounds`.'''

--- a/base/function.py
+++ b/base/function.py
@@ -568,15 +568,26 @@ class chunk(object):
     @utils.multicase(start=six.integer_types, end=six.integer_types)
     @classmethod
     def add(cls, start, end):
-        '''Add the chunk `start` to `end` to the current function.'''
+        '''Add the chunk starting at the address `start` and terminating at `end` to the current function.'''
         return cls.add(ui.current.function(), start, end)
+    @utils.multicase(bounds=tuple)
+    @classmethod
+    def add(cls, bounds):
+        '''Add the chunk specified by `bounds` to the current function.'''
+        return cls.add(ui.current.function(), bounds)
     @utils.multicase(start=six.integer_types, end=six.integer_types)
     @classmethod
     def add(cls, func, start, end):
-        '''Add the chunk `start` to `end` to the function `func`.'''
+        '''Add the chunk starting at the address `start` and terminating at `end` to the function `func`.'''
         fn = by(func)
         start, end = interface.address.inside(start, end)
         return idaapi.append_func_tail(fn, start, end)
+    @utils.multicase(bounds=tuple)
+    @classmethod
+    def add(cls, func, bounds):
+        '''Add the chunk specified by `bounds` to the function `func`.'''
+        start, end = bounds
+        return cls.add(func, start, end)
 
     @utils.multicase()
     @classmethod

--- a/base/function.py
+++ b/base/function.py
@@ -675,7 +675,7 @@ class blocks(object):
         for bb in cls.iterate(func):
             yield interface.range.bounds(bb)
         return
-    @utils.multicase(bounds=interface.bounds_t)
+    @utils.multicase(bounds=tuple)
     def __new__(cls, bounds):
         '''Return each basic block contained within the specified `bounds`.'''
         left, right = bounds

--- a/base/structure.py
+++ b/base/structure.py
@@ -1488,6 +1488,14 @@ class member_t(object):
         '''Return the ending offset of the member.'''
         return self.ptr.eoff
     @property
+    def realbounds(self):
+        ptr = self.ptr
+        return interface.bounds_t(ptr.soff, ptr.eoff)
+    @property
+    def bounds(self):
+        ptr, base = self.ptr, self.__parent.members.baseoffset
+        return interface.bounds_t(ptr.soff, ptr.eoff).translate(base)
+    @property
     def parent(self):
         '''Return the structure_t that owns the member.'''
         return self.__parent


### PR DESCRIPTION
This PR modifes the case definitions in a number of functions which originally used `interface.bounds_t` to a tuple. The `interface.bounds_t` type was not available to users which made these cases unreachable unless a user accessed this internal type directly. These types in the case definition were changed to tuples which should mitigate users have to specify the `bounds_t` entirely. The constructor for the `interface.bounds_t` tuple was also improved to allow using keywords to construct it, and any users of the type were also improved. 

This closes issue #88, and is part of the prerequisites list at https://github.com/arizvisa/ida-minsc/pull/84#issuecomment-740769754.