### PR TITLE
Added cases to all the register filters which allow the user to not need to explicitly specify a register.

### DIFF
--- a/base/_interface.py
+++ b/base/_interface.py
@@ -1478,11 +1478,18 @@ class switch_t(object):
     def range(self):
         '''Return all of the possible cases for the switch.'''
         return tuple(six.moves.range(self.base, self.base + self.count))
-    def __repr__(self):
+    def __str__(self):
         cls = self.__class__
         if self.indirectQ():
-            return "<class '{:s}{{{:d}}}' at {:#x}> default:*{:#x} branch[{:d}]:*{:#x} index[{:d}]:*{:#x} register:{:s}".format(cls.__name__, self.count, self.ea, self.default, self.object.jcases, self.object.jumps, self.object.ncases, self.object.lowcase, self.register)
-        return "<class '{:s}{{{:d}}}' at {:#x}> default:*{:#x} branch[{:d}]:*{:#x} register:{:s}".format(cls.__name__, self.count, self.ea, self.default, self.object.ncases, self.object.jumps, self.register)
+            return "<class '{:s}{{{:d}}}' at {:#x}> default:*{:#x} branch[{:d}]:*{:#x} index[{:d}]:*{:#x} register:{!s}".format(cls.__name__, self.count, self.ea, self.default, self.object.jcases, self.object.jumps, self.object.ncases, self.object.lowcase, self.register)
+        return "<class '{:s}{{{:d}}}' at {:#x}> default:*{:#x} branch[{:d}]:*{:#x} register:{!s}".format(cls.__name__, self.count, self.ea, self.default, self.object.ncases, self.object.jumps, self.register)
+    def __unicode__(self):
+        cls = self.__class__
+        if self.indirectQ():
+            return u"<class '{:s}{{{:d}}}' at {:#x}> default:*{:#x} branch[{:d}]:*{:#x} index[{:d}]:*{:#x} register:{!s}".format(cls.__name__, self.count, self.ea, self.default, self.object.jcases, self.object.jumps, self.object.ncases, self.object.lowcase, self.register)
+        return u"<class '{:s}{{{:d}}}' at {:#x}> default:*{:#x} branch[{:d}]:*{:#x} register:{!s}".format(cls.__name__, self.count, self.ea, self.default, self.object.ncases, self.object.jumps, self.register)
+    def __repr__(self):
+        return u"{!s}".format(self)
 
 def xiterate(ea, start, next):
     '''Utility function for iterating through idaapi's xrefs from `start` to `end`.'''

--- a/base/database.py
+++ b/base/database.py
@@ -1050,7 +1050,7 @@ def name(ea, string, *suffix, **flags):
 
         # if we're pointing to the start of the function, then unless public was explicitly
         # specified we need to set the local name.
-        elif interface.range.start(func) == ea and not all(flag & item for item in [idaapi.SN_PUBLIC, idaapi.SN_NON_PUBLIC]):
+        elif interface.range.start(func) == ea and not builtins.all(flag & item for item in [idaapi.SN_PUBLIC, idaapi.SN_NON_PUBLIC]):
             flag |= idaapi.SN_LOCAL
 
         # if the name is supposed to be in the list, then we need to check if there's a
@@ -2510,20 +2510,20 @@ class address(object):
         iterops = interface.regmatch.modifier(**modifiers)
         uses_register = interface.regmatch.use(regs)
 
-        # if within a function, then make sure we're within the chunk's bounds.
+        # if within a function, then make sure we're within the chunk's bounds and we're a code type
         if function.within(ea):
             (start, _) = function.chunk(ea)
-            fwithin = functools.partial(operator.le, start)
+            fwithin = utils.fcompose(utils.fmap(functools.partial(operator.le, start), type.is_code), builtins.all)
 
         # otherwise ensure that we're not in the function and we're a code type.
         else:
-            fwithin = utils.fcompose(utils.fmap(utils.fcompose(function.within, operator.not_), type.is_code), all)
+            fwithin = utils.fcompose(utils.fmap(utils.fcompose(function.within, operator.not_), type.is_code), builtins.all)
 
             start = cls.__walk__(ea, cls.prev, fwithin)
             start = top() if start == idaapi.BADADDR else start
 
         # define a predicate for cls.walk to continue looping when true
-        Freg = lambda ea: fwithin(ea) and not any(uses_register(ea, opnum) for opnum in iterops(ea))
+        Freg = lambda ea: fwithin(ea) and not builtins.any(uses_register(ea, opnum) for opnum in iterops(ea))
         Fnot = utils.fcompose(predicate, operator.not_)
         F = utils.fcompose(utils.fmap(Freg, Fnot), builtins.any)
 
@@ -2539,6 +2539,10 @@ class address(object):
         if res in {None, idaapi.BADADDR} or (cls == address and res < start):
             # FIXME: include registers in message
             raise E.RegisterNotFoundError(u"{:s}.prevreg({:s}) : Unable to find register{:s} within the chunk {:#x}{:+#x}. Stopped at address {:#x}.".format('.'.join((__name__, cls.__name__)), args, '' if len(regs)==1 else 's', start, ea, res))
+
+        # if the address is not a code type, then recurse so we can skip it.
+        if not type.is_code(res):
+            return cls.prevreg(res, predicate, *regs, **modifiers)
 
         # recurse if the user specified it
         modifiers['count'] = count - 1
@@ -2575,7 +2579,7 @@ class address(object):
         # if within a function, then make sure we're within the chunk's bounds.
         if function.within(ea):
             (_, end) = function.chunk(ea)
-            fwithin = functools.partial(operator.gt, end)
+            fwithin = utils.fcompose(utils.fmap(functools.partial(operator.gt, end), type.is_code), builtins.all)
 
         # otherwise ensure that we're not in a function and we're a code type.
         else:
@@ -2585,7 +2589,7 @@ class address(object):
             end = bottom() if end == idaapi.BADADDR else end
 
         # define a predicate for cls.walk to continue looping when true
-        Freg = lambda ea: fwithin(ea) and not any(uses_register(ea, opnum) for opnum in iterops(ea))
+        Freg = lambda ea: fwithin(ea) and not builtins.any(uses_register(ea, opnum) for opnum in iterops(ea))
         Fnot = utils.fcompose(predicate, operator.not_)
         F = utils.fcompose(utils.fmap(Freg, Fnot), builtins.any)
 
@@ -2601,6 +2605,10 @@ class address(object):
         if res in {None, idaapi.BADADDR} or (cls == address and res >= end):
             # FIXME: include registers in message
             raise E.RegisterNotFoundError(u"{:s}.nextreg({:s}) : Unable to find register{:s} within chunk {:#x}{:+#x}. Stopped at address {:#x}.".format('.'.join((__name__, cls.__name__)), args, '' if len(regs)==1 else 's', ea, end, res))
+
+        # if the address is not a code type, then recurse so we can skip it.
+        if not type.is_code(res):
+            return cls.nextreg(res, predicate, *regs, **modifiers)
 
         # recurse if the user specified it
         modifiers['count'] = count - 1
@@ -2622,11 +2630,19 @@ class address(object):
             logging.warn(u"{:s}.prevstack({:#x}, {:#x}) : This function's semantics are subject to change and may be deprecated in the future..".format('.'.join((__name__, cls.__name__)), ea, delta))
             cls.__prevstack_warning_count__ = getattr(cls, '__prevstack_warning_count__', 0) + 1
 
+        # determine the boundaries that we're not allowed to seek past
         fn, sp = function.top(ea), function.get_spdelta(ea)
         start, _ = function.chunk(ea)
-        res = cls.__walk__(ea, cls.prev, lambda ea: ea >= start and abs(function.get_spdelta(ea) - sp) < delta)
-        if res == idaapi.BADADDR or res < start:
-            raise E.AddressOutOfBoundsError(u"{:s}.prevstack({:#x}, {:+#x}) : Unable to locate instruction matching contraints due to walking past the top ({:#x}) of the function {:#x}. Stopped at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, delta, start, fn, res))
+        fwithin = lambda ea: ea >= start and abs(function.get_spdelta(ea) - sp) < delta
+
+        # walk to the previous major change in the stack delta, and keep
+        # looping if we haven't found it yet.
+        found = False
+        while not found:
+            res = cls.__walk__(ea, cls.prev, fwithin)
+            if res == idaapi.BADADDR or res < start:
+                raise E.AddressOutOfBoundsError(u"{:s}.prevstack({:#x}, {:+#x}) : Unable to locate instruction matching contraints due to encountering the top ({:#x}) of the function {:#x}. Stopped at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, delta, start, fn, res))
+            found, ea = type.is_code(res), cls.prev(res)
         return res
 
     # FIXME: modify this to just locate _any_ amount of change in the sp delta by default
@@ -2645,12 +2661,20 @@ class address(object):
             logging.warn(u"{:s}.nextstack({:#x}, {:#x}) : This function's semantics are subject to change and may be deprecatd in the future.".format('.'.join((__name__, cls.__name__)), ea, delta))
             cls.__nextstack_warning_count__ = getattr(cls, '__nextstack_warning_count__', 0) + 1
 
+        # determine the boundaries that we're not allowed to seek past
         fn, sp = function.top(ea), function.get_spdelta(ea)
         _, end = function.chunk(ea)
-        res = cls.__walk__(ea, cls.next, lambda ea: ea < end and abs(function.get_spdelta(ea) - sp) < delta)
-        if res == idaapi.BADADDR or res >= end:
-            raise E.AddressOutOfBoundsError(u"{:s}.nextstack({:#x}, {:+#x}) : Unable to locate instruction matching contraints due to walking past the bottom ({:#x}) of the function {:#x}. Stopped at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, delta, end, fn, res))
+
+        # walk to the next major change in the stack delta, and keep
+        # looping if we haven't found it yet.
+        found = False
+        while not found:
+            res = cls.__walk__(ea, cls.next, lambda ea: ea < end and abs(function.get_spdelta(ea) - sp) < delta)
+            if res == idaapi.BADADDR or res >= end:
+                raise E.AddressOutOfBoundsError(u"{:s}.nextstack({:#x}, {:+#x}) : Unable to locate instruction matching contraints due to encountering the bottom ({:#x}) of the function {:#x}. Stopped at {:#x}.".format('.'.join((__name__, cls.__name__)), ea, delta, end, fn, res))
+            found, ea = type.is_code(res), cls.next(res)
         return res
+
     prevdelta, nextdelta = utils.alias(prevstack, 'address'), utils.alias(nextstack, 'address')
 
     @utils.multicase()
@@ -3777,7 +3801,7 @@ class xref(object):
 
             # if the current instruction is a non-"stop" instruction, then it will
             # include a reference to the next instruction. so, we'll remove it.
-            if type.is_code(ea) and _instruction.feature(ea) & idaapi.CF_STOP != idaapi.CF_STOP:
+            if type.is_code(ea) and _instruction.type.feature(ea, idaapi.CF_STOP) != idaapi.CF_STOP:
                 res.discard(next_ea)
 
         except E.OutOfBoundsError:
@@ -3807,7 +3831,7 @@ class xref(object):
 
             # if the previous instruction is a non-"stop" instruction, then it will
             # reference the current instruction which is a reason to remove it.
-            if type.is_code(prev_ea) and _instruction.feature(prev_ea) & idaapi.CF_STOP != idaapi.CF_STOP:
+            if type.is_code(prev_ea) and _instruction.type.feature(prev_ea, idaapi.CF_STOP) != idaapi.CF_STOP:
                 res.discard(prev_ea)
 
         except E.OutOfBoundsError:
@@ -3937,7 +3961,7 @@ class xref(object):
     def erase(ea):
         '''Clear all references at the address `ea`.'''
         ea = interface.address.inside(ea)
-        return all(ok for ok in (xref.rm_code(ea), xref.rm_data(ea)))
+        return builtins.all(ok for ok in (xref.rm_code(ea), xref.rm_data(ea)))
     rx = utils.alias(rm_data, 'xref')
 
 x = xref    # XXX: ns alias

--- a/base/database.py
+++ b/base/database.py
@@ -142,16 +142,17 @@ class config(object):
     def type(cls, typestr):
         '''Evaluates a type string and returns its size according to the compiler used by the database.'''
         lookup = {
-            'bool':'size_b',
-            'short':'size_s',
-            'int':'size_i', 'float':'size_l', 'single':'size_l',
-            'long':'size_l',
-            'longlong':'size_ll', 'double':'size_ll',
-            'enum':'size_e',
-            'longdouble':'size_ldbl',
-            'align':'defalign', 'alignment':'defalign',
+            'bool': 'size_b',
+            'short': 'size_s',
+            'int': 'size_i', 'float': 'size_l', 'single': 'size_l',
+            'long': 'size_l',
+            'longlong': 'size_ll', 'double': 'size_ll',
+            'enum': 'size_e',
+            'longdouble': 'size_ldbl',
+            'align': 'defalign', 'alignment': 'defalign',
         }
-        return getattr(cls.compiler(), lookup.get(typestr.translate(None, ' ').lower(), typestr) )
+        string = typestr.replace(' ', '')
+        return getattr(cls.compiler(), lookup.get(string.lower(), typestr.lower()))
 
     @classmethod
     def bits(cls):
@@ -198,7 +199,7 @@ class config(object):
         '''Return the bounds of the current database in a tuple formatted as `(left, right)`.'''
         return interface.bounds_t(cls.info.minEA, cls.info.maxEA)
 
-    class registers(object):
+    class register(object):
         """
         This namespace returns the available register names and their
         sizes for the database.
@@ -226,9 +227,9 @@ class config(object):
             res = idaapi.ph_get_regDataSreg() if idaapi.__version__ < 7.0 else idaapi.ph_get_reg_data_sreg()
             return cls.names()[res]
         @classmethod
-        def segmentsize(cls):
+        def segmentbits(cls):
             '''Return the segment register size for the database.'''
-            return idaapi.ph_get_segreg_size()
+            return 8 * idaapi.ph_get_segreg_size()
 
 range = utils.alias(config.bounds, 'config')
 filename, idb, module, path = utils.alias(config.filename, 'config'), utils.alias(config.idb, 'config'), utils.alias(config.module, 'config'), utils.alias(config.path, 'config')

--- a/base/function.py
+++ b/base/function.py
@@ -1344,8 +1344,8 @@ class block(object):
     @classmethod
     def register(cls, bounds, reg, *regs, **modifiers):
         '''Yield each `(address, opnum, state)` within the block identified by `bounds` that uses `reg` or any one of the registers in `regs`.'''
-        B = cls.at(bounds)
-        return cls.register(B, reg, *regs, **modifiers)
+        bb = cls.at(bounds)
+        return cls.register(bb, reg, *regs, **modifiers)
     @utils.multicase(bb=idaapi.BasicBlock, reg=(basestring, interface.register_t))
     @classmethod
     def register(cls, bb, reg, *regs, **modifiers):

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -297,7 +297,7 @@ def ops_state(ea):
     ea = interface.address.inside(ea)
     f = type.feature(ea)
     res = ( ((f&ops_state.read[i]), (f&ops_state.write[i])) for i in six.moves.range(ops_count(ea)) )
-    return tuple((r and 'r' or '') + (w and 'w' or '') for r, w in res)
+    return tuple(interface.reftype_t.of_action((r and 'r' or '') + (w and 'w' or '')) for r, w in res)
 
 # pre-cache the CF_ flags from idaapi inside ops_state
 ops_state.read, ops_state.write = zip(*((getattr(idaapi, "CF_USE{:d}".format(idx + 1), 1 << (7 + idx)), getattr(idaapi, "CF_CHG{:d}".format(idx + 1), 1 << (1 + idx))) for idx in six.moves.range(idaapi.UA_MAXOP)))

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -129,17 +129,6 @@ def size(ea):
     '''Returns the length of the instruction at the address `ea`.'''
     return at(ea).size
 
-@utils.multicase()
-def feature():
-    '''Returns the feature bitmask of the instruction at the current address.'''
-    return feature(ui.current.address())
-@utils.multicase(ea=six.integer_types)
-def feature(ea):
-    '''Return the feature bitmask for the instruction at the address `ea`.'''
-    if database.type.is_code(ea):
-        return at(ea).get_canon_feature()
-    return None
-
 @utils.multicase(opnum=six.integer_types)
 def opinfo(opnum):
     '''Returns the ``idaapi.opinfo_t`` for the operand `opnum` belonging to the instruction at the current address.'''
@@ -306,7 +295,7 @@ def ops_state():
 def ops_state(ea):
     '''Returns a tuple of for all the operands containing one of the states "r", "w", or "rw" describing how the operands are modified for the instruction at address `ea`.'''
     ea = interface.address.inside(ea)
-    f = feature(ea)
+    f = type.feature(ea)
     res = ( ((f&ops_state.read[i]), (f&ops_state.write[i])) for i in six.moves.range(ops_count(ea)) )
     return tuple((r and 'r' or '') + (w and 'w' or '') for r, w in res)
 
@@ -403,7 +392,7 @@ def op_state(ea, opnum):
     The returned state is a string that can be "r", "w", or "rw" depending on
     whether the operand is being read from, written to, or modified (both).
     """
-    f = feature(ea)
+    f = type.feature(ea)
     r, w = f&ops_state.read[opnum], f&ops_state.write[opnum]
     res = (r and 'r' or '') + (w and 'w' or '')
 
@@ -1248,6 +1237,26 @@ class type(object):
     """
     @utils.multicase()
     @classmethod
+    def feature(cls):
+        '''Returns the feature bitmask of the instruction at the current address.'''
+        return cls.feature(ui.current.address())
+    @utils.multicase(ea=six.integer_types)
+    @classmethod
+    def feature(cls, ea):
+        '''Return the feature bitmask for the instruction at the address `ea`.'''
+        if database.type.is_code(ea):
+            return at(ea).get_canon_feature()
+        return None
+    @utils.multicase(ea=six.integer_types, mask=six.integer_types)
+    @classmethod
+    def feature(cls, ea, mask):
+        '''Return the feature bitmask for the instruction at the address `ea` masked with `mask`.'''
+        if database.type.is_code(ea):
+            return at(ea).get_canon_feature() & idaapi.as_uint32(mask)
+        return None
+
+    @utils.multicase()
+    @classmethod
     def is_sentinel(cls):
         '''Returns true if the current instruction is a sentinel-type instruction.'''
         return cls.is_sentinel(ui.current.address())
@@ -1256,7 +1265,7 @@ class type(object):
     def is_sentinel(cls, ea):
         '''Returns true if the instruction at `ea` is a sentinel-type instruction.'''
         ea = interface.address.inside(ea)
-        return database.type.is_code(ea) and all([feature(ea) & idaapi.CF_STOP])
+        return database.type.is_code(ea) and all([cls.feature(ea, idaapi.CF_STOP)])
     issentinel = sentinelQ = utils.alias(is_sentinel, 'type')
 
     @utils.multicase()
@@ -1268,9 +1277,9 @@ class type(object):
     @classmethod
     def is_return(cls, ea):
         '''Returns true if the instruction at `ea` is a return-type instruction.'''
-        ea = interface.address.inside(ea)
-        F, (Xci, Xdi) = feature(ea), (interface.xiterate(ea, ffirst, fnext) for ffirst, fnext in [(idaapi.get_first_cref_from, idaapi.get_next_cref_from), (idaapi.get_first_dref_from, idaapi.get_next_dref_from)])
-        Xc, Xd = ([item for item in X] for X in [Xci, Xdi])
+        ea, Xcfilter = interface.address.inside(ea), {idaapi.get_item_end(ea)}
+        F, (Xci, Xdi) = cls.feature(ea), (interface.xiterate(ea, ffirst, fnext) for ffirst, fnext in [(idaapi.get_first_cref_from, idaapi.get_next_cref_from), (idaapi.get_first_dref_from, idaapi.get_next_dref_from)])
+        Xc, Xd = ([item for item in X] for X in [(item for item in Xci if item not in Xcfilter), Xdi])
         return cls.is_sentinel(ea) and not any([F & idaapi.CF_JUMP, Xc, Xd])
     isreturn = returnQ = retQ = utils.alias(is_return, 'type')
 
@@ -1284,7 +1293,7 @@ class type(object):
     def is_shift(cls, ea):
         '''Returns true if the instruction at `ea` is a bit-shifting instruction.'''
         ea = interface.address.inside(ea)
-        return database.type.is_code(ea) and all([feature(ea) & idaapi.CF_SHFT])
+        return database.type.is_code(ea) and all([cls.feature(ea, idaapi.CF_SHFT)])
     isshift = shiftQ = utils.alias(is_shift, 'type')
 
     @utils.multicase()
@@ -1296,10 +1305,10 @@ class type(object):
     @classmethod
     def is_branch(cls, ea):
         '''Returns true if the instruction at `ea` is any kind of branch.'''
-        ea = interface.address.inside(ea)
-        F, (Xci, Xdi) = feature(ea), (interface.xiterate(ea, ffirst, fnext) for ffirst, fnext in [(idaapi.get_first_cref_from, idaapi.get_next_cref_from), (idaapi.get_first_dref_from, idaapi.get_next_dref_from)])
-        Xc, Xd = ([item for item in X] for X in [Xci, Xdi])
-        return database.type.is_code(ea) and all([not any([F & idaapi.CF_CALL, F & idaapi.CF_SHFT]), any([F & idaapi.CF_JUMP, Xc, Xd])])
+        ea, Xcfilter = interface.address.inside(ea), {idaapi.get_item_end(ea)}
+        F, (Xci, Xdi) = cls.feature(ea), (interface.xiterate(ea, ffirst, fnext) for ffirst, fnext in [(idaapi.get_first_cref_from, idaapi.get_next_cref_from), (idaapi.get_first_dref_from, idaapi.get_next_dref_from)])
+        Xc, Xd = ([item for item in X] for X in [(item for item in Xci if item not in Xcfilter), Xdi])
+        return database.type.is_code(ea) and all([not any([F & idaapi.CF_CALL, F & idaapi.CF_SHFT]), any([F & idaapi.CF_JUMP, Xc])])
     isbranch = branchQ = utils.alias(is_branch, 'type')
 
     @utils.multicase()
@@ -1312,7 +1321,7 @@ class type(object):
     def is_jmp(cls, ea):
         '''Returns true if the instruction at `ea` is an immediate and indirect branch.'''
         ea = interface.address.inside(ea)
-        return cls.is_branch(ea) and all([feature(ea) & idaapi.CF_STOP])
+        return cls.is_branch(ea) and all([cls.feature(ea, idaapi.CF_STOP)])
     isjmp = jmpQ = utils.alias(is_jmp, 'type')
 
     @utils.multicase()
@@ -1325,7 +1334,7 @@ class type(object):
     def is_jxx(cls, ea):
         '''Returns true if the instruction at `ea` is a conditional branch.'''
         ea = interface.address.inside(ea)
-        return cls.is_branch(ea) and not all([feature(ea) & idaapi.CF_STOP])
+        return cls.is_branch(ea) and not all([cls.feature(ea, idaapi.CF_STOP)])
     isjxx = jxxQ = utils.alias(is_jxx, 'type')
 
     @utils.multicase()
@@ -1338,7 +1347,7 @@ class type(object):
     def is_jmpi(cls, ea):
         '''Returns true if the instruction at `ea` is an indirect branch.'''
         ea = interface.address.inside(ea)
-        return cls.is_branch(ea) and all([feature(ea) & idaapi.CF_JUMP])
+        return cls.is_branch(ea) and all([cls.feature(ea, idaapi.CF_JUMP)])
     isjmpi = jmpiQ = utils.alias(is_jmpi, 'type')
 
     @utils.multicase()
@@ -1354,7 +1363,7 @@ class type(object):
         if idaapi.__version__ < 7.0 and hasattr(idaapi, 'is_call_insn'):
             idaapi.decode_insn(ea)
             return idaapi.is_call_insn(ea)
-        return database.type.is_code(ea) and all([feature(ea) & idaapi.CF_CALL])
+        return database.type.is_code(ea) and all([cls.feature(ea, idaapi.CF_CALL)])
     iscall = callQ = utils.alias(is_call, 'type')
 
     @utils.multicase()
@@ -1367,12 +1376,13 @@ class type(object):
     def is_calli(cls, ea):
         '''Returns true if the instruction at `ea` is an indirect call.'''
         ea = interface.address.inside(ea)
-        F = feature(ea)
+        F = cls.feature(ea)
         return database.type.is_code(ea) and all([F & idaapi.CF_CALL, F & idaapi.CF_JUMP])
     iscalli = calliQ = utils.alias(is_calli, 'type')
 
 t = type    # XXX: ns alias
 
+feature = utils.alias(type.feature, 'type')
 is_return = returnQ = retQ = utils.alias(type.is_return, 'type')
 is_shift = shiftQ = utils.alias(type.is_shift, 'type')
 is_branch = branchQ = utils.alias(type.is_branch, 'type')

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -337,13 +337,6 @@ ops_const = utils.alias(ops_constant)
 def ops_register(**modifiers):
     '''Yields the index of each operand in the instruction at the current address which uses a register.'''
     return ops_register(ui.current.address(), **modifiers)
-@utils.multicase(reg=(basestring, interface.register_t))
-def ops_register(reg, *regs, **modifiers):
-    """Yields the index of each operand in the instruction at the current address that uses `reg` or any one of the registers in `regs`.
-
-    If the keyword `write` is true, then only return the result if it's writing to the register.
-    """
-    return ops_register(ui.current.address(), reg, *regs, **modifiers)
 @utils.multicase()
 def ops_register(ea, **modifiers):
     '''Yields the index of each operand in the instruction at the address `ea` which uses a register.'''
@@ -351,6 +344,10 @@ def ops_register(ea, **modifiers):
     iterops = interface.regmatch.modifier(**modifiers)
     fregisterQ = utils.fcompose(op, utils.fcondition(utils.finstance(interface.symbol_t))(utils.fcompose(utils.fattribute('symbols'), functools.partial(map, utils.finstance(interface.register_t)), any), utils.fconstant(False)))
     return tuple(filter(functools.partial(fregisterQ, ea), iterops(ea)))
+@utils.multicase(reg=(basestring, interface.register_t))
+def ops_register(reg, *regs, **modifiers):
+    '''Yields the index of each operand in the instruction at the current address that uses `reg` or any one of the registers in `regs`.'''
+    return ops_register(ui.current.address(), reg, *regs, **modifiers)
 @utils.multicase(reg=(basestring, interface.register_t))
 def ops_register(ea, reg, *regs, **modifiers):
     """Yields the index of each operand in the instruction at address `ea` that uses `reg` or any one of the registers in `regs`.

--- a/base/structure.py
+++ b/base/structure.py
@@ -745,14 +745,17 @@ def members(id):
         # grab the member's boundaries
         left, right = m.soff, m.eoff
 
+        # if our offset doesn't match the beginning of the member, then
+        # this is padding that is undefined or unamed which we need to
+        # yield to the caller.
+        if offset < left:
+            yield (offset, left - offset), (None, None, None)
+            offset = left
+
         # grab the member's attributes
         res = map(utils.string.of, (idaapi.get_member_name(m.id), idaapi.get_member_cmt(m.id, 0), idaapi.get_member_cmt(m.id, 1)))
 
         # yield our current position and iterate to the next member
-        if offset < left:
-            yield (offset, left-offset), tuple(res)
-            offset = left
-
         yield (offset, ms), tuple(res)
         offset += ms
     return


### PR DESCRIPTION
This PR adds another case to each of the register filtering functions such as `instruction.ops_register`, or `function.register` in order to allow the user to not need to explicitly specify a register. A number of the functions in the `database.address` namespace were also modified to skip over non-code that was found within a function or code segment.

This closes issue #90, and is part of the prerequisites list at https://github.com/arizvisa/ida-minsc/pull/84#issuecomment-740769754.