### PR TITLE
Fixed the implementation of the `database.set.unknown` function to always return the size of its undefined data.

### DIFF
--- a/base/database.py
+++ b/base/database.py
@@ -3046,7 +3046,7 @@ class type(object):
         # Check if we're pointing at an export or directly at a function. If we
         # are, then we need to use function.type.
         try:
-            rt, ea = interface.addressOfRuntimeOrStatic(func)
+            rt, ea = interface.addressOfRuntimeOrStatic(ea)
             if rt or function.address(ea) == ea:
                 return function.type(ea, info)
 
@@ -3430,7 +3430,7 @@ class type(object):
         '''Return true if the address at `ea` is defined as a structure.'''
         FF_STRUCT = idaapi.FF_STRUCT if hasattr(idaapi, 'FF_STRUCT') else idaapi.FF_STRU
         return type.flags(ea, idaapi.DT_TYPE) == FF_STRUCT
-    structQ = is_struc = is_struct = utils.alias(is_structure, 'type')
+    structQ = structureQ = is_struc = is_struct = utils.alias(is_structure, 'type')
 
     @utils.multicase()
     @staticmethod

--- a/base/database.py
+++ b/base/database.py
@@ -5161,7 +5161,10 @@ class set(object):
         def __new__(cls, ea):
             '''Sets the data at address `ea` to an IEEE-754 floating-point number based on its size.'''
             size = type.size(ea)
-            if size == 4:
+            if size < 4 and type.is_unknown(ea, 4):
+                logging.warning(u"{:s}({:#x}) : Promoting number at address {:#x} to 32-bit single due to item size ({:+d}) being less than the smallest available IEEE-754 number ({:+d}).".format('.'.join([__name__, 'set', cls.__name__]), ea, size, 4))
+                return cls.single(ea)
+            elif size == 4:
                 return cls.single(ea)
             elif size == 8:
                 return cls.double(ea)
@@ -5527,6 +5530,9 @@ class get(object):
             elif size == 4:
                 return cls.single(ea, **byteorder)
             elif size == 8:
+                return cls.double(ea, **byteorder)
+            elif size > 8:
+                logging.warning(u"{:s}({:#x}) : Demoting size ({:+d}) for floating-point number at {:#x} down to largest available IEEE-754 number ({:+d}).".format('.'.join([__name__, 'get', cls.__name__]), size, ea, 8))
                 return cls.double(ea, **byteorder)
             raise E.InvalidTypeOrValueError(u"{:s}({:#x}) : Unable to determine the type of floating-point number for the item's size ({:+#x}).".format('.'.join((__name__, 'get', cls.__name__)), ea, size))
 

--- a/base/database.py
+++ b/base/database.py
@@ -4946,7 +4946,7 @@ class set(object):
         def sint16_t(cls, ea):
             '''Set the data at address `ea` to a sint16_t.'''
             res = set.unknown(ea, 2)
-            if not type.is_unkonwn(ea, 2) or res < 2:
+            if not type.is_unknown(ea, 2) or res < 2:
                 raise E.DisassemblerError(u"{:s}.sint16_t({:#x}) : Unable to undefine {:d} bytes for the integer.".format('.'.join((__name__, 'set', cls.__name__)), ea, 2))
 
             # Apply our data type after undefining it

--- a/base/database.py
+++ b/base/database.py
@@ -3456,7 +3456,7 @@ class type(object):
 
             > type, length = database.t.array()
             > print database.t.array.size(ea)
-            > print database.t.array.type(ea)
+            > print database.t.array.member(ea)
             > print database.t.array.element(ea)
             > print database.t.array.length(ea)
 
@@ -3488,39 +3488,39 @@ class type(object):
 
         @utils.multicase()
         @classmethod
-        def type(cls):
+        def member(cls):
             '''Return the type for the member of the array at the current address.'''
-            return cls.type(ui.current.address())
+            return cls.member(ui.current.address())
         @utils.multicase(ea=six.integer_types)
         @classmethod
-        def type(cls, ea):
+        def member(cls, ea):
             '''Return the type for the member of the array at the address specified by `ea`.'''
             res, _ = cls(ea)
             return res
 
         @utils.multicase()
         @classmethod
-        def info(cls):
+        def element(cls):
             '''Return the type information for the member of the array defined at the current address.'''
-            return cls.info(ui.current.address())
+            return cls.element(ui.current.address())
         @utils.multicase(ea=six.integer_types)
         @classmethod
-        def info(cls, ea):
+        def element(cls, ea):
             '''Return the type information for the member of the array defined at the address specified by `ea`.'''
             ti = type(ea)
             if ti is None:
                 raise E.MissingTypeOrAttribute(u"{:s}.info({:#x}) : Unable to fetch any type information from the address at {:#x}.".format('.'.join((__name__, 'type', cls.__name__)), ea, ea))
             return ti.get_array_element() if ti.is_array() else ti
-        typeinfo = utils.alias(info, 'type.array')
+        info = typeinfo = utils.alias(element, 'type.array')
 
         @utils.multicase()
         @classmethod
-        def element(cls):
+        def size(cls):
             '''Return the size of a member in the array at the current address.'''
-            return cls.element(ui.current.address())
+            return cls.size(ui.current.address())
         @utils.multicase(ea=six.integer_types)
         @classmethod
-        def element(cls, ea):
+        def size(cls, ea):
             '''Return the size of a member in the array at the address specified by `ea`.'''
             FF_STRUCT = idaapi.FF_STRUCT if hasattr(idaapi, 'FF_STRUCT') else idaapi.FF_STRU
 
@@ -3539,17 +3539,6 @@ class type(object):
             ea, F = interface.address.within(ea), type.flags(ea)
             sz, ele = idaapi.get_item_size(ea), idaapi.get_full_data_elsize(ea, F)
             return sz // ele
-
-        @utils.multicase()
-        @classmethod
-        def size(cls):
-            '''Return the total size of the array at the current address.'''
-            return type.size(ui.current.address())
-        @utils.multicase(ea=six.integer_types)
-        @classmethod
-        def size(cls, ea):
-            '''Return the total size of the array at the address specified by `ea`.'''
-            return type.size(ea)
 
     class structure(object):
         """
@@ -3601,12 +3590,14 @@ class type(object):
         @classmethod
         def size(cls):
             '''Return the total size of the structure at the current address.'''
-            return type.size(ui.current.address())
+            return cls.size(ui.current.address())
         @utils.multicase(ea=six.integer_types)
         @classmethod
         def size(cls, ea):
             '''Return the total size of the structure at address `ea`.'''
-            return type.size(ea)
+            id = cls.id(ea)
+            ptr = idaapi.get_struc(id)
+            return idaapi.get_struc_size(ptr)
     struc = struct = structure  # ns alias
 
     @utils.multicase()

--- a/base/function.py
+++ b/base/function.py
@@ -227,29 +227,6 @@ def name(func, string, *suffix, **flags):
     return database.name(ea, string, **flags)
 
 @utils.multicase()
-def convention():
-    '''Return the calling convention of the current function.'''
-    # use ui.current.address() instead of ui.current.function() to deal with import table entries
-    return convention(ui.current.address())
-@utils.multicase()
-def convention(func):
-    """Return the calling convention of the function `func`.
-
-    The integer returned corresponds to one of the ``idaapi.CM_CC_*`` constants.
-    """
-    rt, ea = interface.addressOfRuntimeOrStatic(func)
-    view = internal.netnode.sup.get(ea, 0x3000, type=memoryview)
-    if view is None:
-        raise E.MissingTypeOrAttribute(u"{:s}.convention({!r}) : Specified function does not contain a prototype declaration.".format(__name__, func))
-    sup = view.tobytes()
-    try:
-        _, _, cc = interface.node.sup_functype(sup)
-    except E.UnsupportedCapability:
-        raise E.UnsupportedCapability(u"{:s}.convention({!r}) : Specified prototype declaration is a type forward which is currently unimplemented.".format(__name__, func))
-    return cc
-cc = utils.alias(convention)
-
-@utils.multicase()
 def prototype():
     '''Return the prototype of the current function if it has one.'''
     # use ui.current.address() instead of ui.current.function() to deal with import table entries
@@ -2219,4 +2196,30 @@ class type(object):
         return database.type.has_typeinfo(ea)
     prototypeQ = has_typeinfo = typeinfoQ = utils.alias(has_prototype, 'type')
 
+    @utils.multicase()
+    @classmethod
+    def convention(cls):
+        '''Return the calling convention of the current function.'''
+        # use ui.current.address() instead of ui.current.function() to deal with import table entries
+        return cls.convention(ui.current.address())
+    @utils.multicase()
+    @classmethod
+    def convention(cls, func):
+        """Return the calling convention of the function `func`.
+
+        The integer returned corresponds to one of the ``idaapi.CM_CC_*`` constants.
+        """
+        rt, ea = interface.addressOfRuntimeOrStatic(func)
+        view = internal.netnode.sup.get(ea, 0x3000, type=memoryview)
+        if view is None:
+            raise E.MissingTypeOrAttribute(u"{:s}.convention({!r}) : Specified function does not contain a prototype declaration.".format(__name__, func))
+        sup = view.tobytes()
+        try:
+            _, _, cc = interface.node.sup_functype(sup)
+        except E.UnsupportedCapability:
+            raise E.UnsupportedCapability(u"{:s}.convention({!r}) : Specified prototype declaration is a type forward which is currently unimplemented.".format(__name__, func))
+        return cc
+    cc = utils.alias(convention)
+
 t = type # XXX: ns alias
+convention = cc = utils.alias(type.convention, 'type')


### PR DESCRIPTION
This PR fixes a number of the functions within the `database.set.integer` and `database.set.float` namespaces that occurred due to them trusting that `database.set.unknown` would always return the size of its undefined data. The issue was that when `database.set.unknown` was applied to already undefined data, 0 would be returned due to the failure of `idaapi.del_items`. This is fixed by explicitly checking whether the data is unknown after being applied, and falling back to returning the item size if so.

This closes issue #92, and is part of the prerequisites list at https://github.com/arizvisa/ida-minsc/pull/84#issuecomment-740769754.