### PR TITLE
Removed some duplicate code from the `database` module and fixed both the `names` and `imports` namespaces.

### DIFF
--- a/base/database.py
+++ b/base/database.py
@@ -3608,7 +3608,8 @@ class type(object):
         ea = interface.address.inside(ea)
 
         # FIXME: this doesn't seem like the right way to determine an instruction is reffing an import
-        return len(database.dxdown(ea)) == len(database.cxdown(ea)) and len(database.cxdown(ea)) > 0
+        datarefs, coderefs = xref.data_down(ea), xref.code_down(ea)
+        return len(datarefs) == len(coderefs) and len(coderefs) > 0
     isimportref = importrefQ = utils.alias(is_importref, 'type')
 
     @utils.multicase()
@@ -3623,7 +3624,8 @@ class type(object):
         ea = interface.address.inside(ea)
 
         # FIXME: this doesn't seem like the right way to determine this...
-        return len(database.dxdown(ea)) > len(database.cxdown(ea))
+        datarefs, coderefs = xref.data_down(ea), xref.code_down(ea)
+        return len(datarefs) > len(coderefs)
     isglobalref = globalrefQ = utils.alias(is_globalref, 'type')
 
 t = type    # XXX: ns alias

--- a/base/database.py
+++ b/base/database.py
@@ -1606,9 +1606,9 @@ def tag(ea, key, none):
     if key == '__name__':
         return name(ea, None, listed=True)
     if key == '__extra_prefix__':
-        return extra.__del_prefix__(ea)
+        return extra.__delete_prefix__(ea)
     if key == '__extra_suffix__':
-        return extra.__del_suffix__(ea)
+        return extra.__delete_suffix__(ea)
     if key == '__typeinfo__':
         return type(ea, None)
     if key == '__color__':
@@ -3347,8 +3347,6 @@ class type(object):
     @staticmethod
     def has_typeinfo(ea):
         '''Return true if the address at `ea` has some typeinfo associated with it.'''
-        return type(ea) is not None
-
         try:
             ok = type(ea) is not None
 
@@ -4278,7 +4276,7 @@ class extra(object):
             # an exception before this happens would imply failure
             return True
         @classmethod
-        def __del__(cls, ea, base):
+        def __delete__(cls, ea, base):
             '''Remove the extra comment(s) for the address ``ea`` at the index ``base``.'''
             sup = internal.netnode.sup
 
@@ -4322,7 +4320,7 @@ class extra(object):
             # return how many newlines there were
             return string.count('\n')
         @classmethod
-        def __del__(cls, ea, base):
+        def __delete__(cls, ea, base):
             '''Remove the extra comment(s) for the address ``ea`` at the index ``base``.'''
 
             # count the number of extra comments to remove
@@ -4349,31 +4347,31 @@ class extra(object):
 
     @utils.multicase(ea=six.integer_types)
     @classmethod
-    def __del_prefix__(cls, ea):
+    def __delete_prefix__(cls, ea):
         '''Delete the prefixed comment at address `ea`.'''
         res = cls.__get__(ea, idaapi.E_PREV)
-        cls.__del__(ea, idaapi.E_PREV)
+        cls.__delete__(ea, idaapi.E_PREV)
         return res
     @utils.multicase(ea=six.integer_types)
     @classmethod
-    def __del_suffix__(cls, ea):
+    def __delete_suffix__(cls, ea):
         '''Delete the suffixed comment at address `ea`.'''
         res = cls.__get__(ea, idaapi.E_NEXT)
-        cls.__del__(ea, idaapi.E_NEXT)
+        cls.__delete__(ea, idaapi.E_NEXT)
         return res
 
     @utils.multicase(ea=six.integer_types, string=basestring)
     @classmethod
     def __set_prefix__(cls, ea, string):
         '''Set the prefixed comment at address `ea` to the specified `string`.'''
-        res, ok = cls.__del_prefix__(ea), cls.__set__(ea, string, idaapi.E_PREV)
+        res, ok = cls.__delete_prefix__(ea), cls.__set__(ea, string, idaapi.E_PREV)
         ok = cls.__set__(ea, string, idaapi.E_PREV)
         return res
     @utils.multicase(ea=six.integer_types, string=basestring)
     @classmethod
     def __set_suffix__(cls, ea, string):
         '''Set the suffixed comment at address `ea` to the specified `string`.'''
-        res, ok = cls.__del_suffix__(ea), cls.__set__(ea, string, idaapi.E_NEXT)
+        res, ok = cls.__delete_suffix__(ea), cls.__set__(ea, string, idaapi.E_NEXT)
         return res
 
     @utils.multicase()
@@ -4388,14 +4386,14 @@ class extra(object):
         return cls.__get_suffix__(ui.current.address())
     @utils.multicase()
     @classmethod
-    def __del_prefix__(cls):
+    def __delete_prefix__(cls):
         '''Delete the prefixed comment at the current address.'''
-        return cls.__del_prefix__(ui.current.address())
+        return cls.__delete_prefix__(ui.current.address())
     @utils.multicase()
     @classmethod
-    def __del_suffix__(cls):
+    def __delete_suffix__(cls):
         '''Delete the suffixed comment at the current address.'''
-        return cls.__del_suffix__(ui.current.address())
+        return cls.__delete_suffix__(ui.current.address())
     @utils.multicase(string=basestring)
     @classmethod
     def __set_prefix__(cls, string):
@@ -4421,7 +4419,7 @@ class extra(object):
     @classmethod
     def prefix(cls, none):
         '''Delete the prefixed comment at the current address.'''
-        return cls.__del_prefix__(ui.current.address())
+        return cls.__delete_prefix__(ui.current.address())
     @utils.multicase(ea=six.integer_types)
     @classmethod
     def prefix(cls, ea):
@@ -4436,7 +4434,7 @@ class extra(object):
     @classmethod
     def prefix(cls, ea, none):
         '''Delete the prefixed comment at address `ea`.'''
-        return cls.__del_prefix__(ea)
+        return cls.__delete_prefix__(ea)
 
     @utils.multicase()
     @classmethod
@@ -4452,7 +4450,7 @@ class extra(object):
     @classmethod
     def suffix(cls, none):
         '''Delete the suffixed comment at the current address.'''
-        return cls.__del_suffix__(ui.current.address())
+        return cls.__delete_suffix__(ui.current.address())
     @utils.multicase(ea=six.integer_types)
     @classmethod
     def suffix(cls, ea):
@@ -4467,7 +4465,7 @@ class extra(object):
     @classmethod
     def suffix(cls, ea, none):
         '''Delete the suffixed comment at address `ea`.'''
-        return cls.__del_suffix__(ea)
+        return cls.__delete_suffix__(ea)
 
     @classmethod
     def __insert_space(cls, ea, count, getter_setter_remover):
@@ -4488,26 +4486,26 @@ class extra(object):
     @classmethod
     def preinsert(cls, ea, count):
         '''Insert `count` lines in front of the item at address `ea`.'''
-        res = cls.__get_prefix__, cls.__set_prefix__, cls.__del_prefix__
+        res = cls.__get_prefix__, cls.__set_prefix__, cls.__delete_prefix__
         return cls.__insert_space(ea, count, res)
     @utils.multicase(ea=six.integer_types, count=six.integer_types)
     @classmethod
     def preappend(cls, ea, count):
         '''Append `count` lines in front of the item at address `ea`.'''
-        res = cls.__get_prefix__, cls.__set_prefix__, cls.__del_prefix__
+        res = cls.__get_prefix__, cls.__set_prefix__, cls.__delete_prefix__
         return cls.__append_space(ea, count, res)
 
     @utils.multicase(ea=six.integer_types, count=six.integer_types)
     @classmethod
     def postinsert(cls, ea, count):
         '''Insert `count` lines after the item at address `ea`.'''
-        res = cls.__get_suffix__, cls.__set_suffix__, cls.__del_suffix__
+        res = cls.__get_suffix__, cls.__set_suffix__, cls.__delete_suffix__
         return cls.__insert_space(ea, count, res)
     @utils.multicase(ea=six.integer_types, count=six.integer_types)
     @classmethod
     def postappend(cls, ea, count):
         '''Append `count` lines after the item at address `ea`.'''
-        res = cls.__get_suffix__, cls.__set_suffix__, cls.__del_suffix__
+        res = cls.__get_suffix__, cls.__set_suffix__, cls.__delete_suffix__
         return cls.__append_space(ea, count, res)
 
     @utils.multicase(count=six.integer_types)

--- a/base/database.py
+++ b/base/database.py
@@ -750,20 +750,36 @@ class names(object):
             raise E.SearchResultsError(u"{:s}.search({:s}) : Found 0 matching results.".format('.'.join((__name__, cls.__name__)), query_s))
         return idaapi.get_nlist_ea(res)
 
+    @utils.multicase()
     @classmethod
-    def name(cls, ea):
-        '''Return the symbol name of the string at address `ea`.'''
+    def symbol(cls):
+        '''Return the symbol name of the current address.'''
+        return cls.symbol(ui.current.address())
+    @utils.multicase(ea=six.integer_types)
+    @classmethod
+    def symbol(cls, ea):
+        '''Return the symbol name of the address `ea`.'''
         res = idaapi.get_nlist_idx(ea)
         return utils.string.of(idaapi.get_nlist_name(res))
+    name = utils.alias(symbol, 'names')
+
     @classmethod
     def address(cls, index):
-        '''Return the address of the string at `index`.'''
+        '''Return the address of the symbol at `index`.'''
         return idaapi.get_nlist_ea(index)
+
+    @utils.multicase()
+    @classmethod
+    def at(cls):
+        '''Return the index, symbol address, and name at the current address.'''
+        return cls.at(ui.current.address())
+    @utils.multicase(ea=six.integer_types)
     @classmethod
     def at(cls, ea):
+        '''Return the index, symbol address, and name at the address `ea`.'''
         idx = idaapi.get_nlist_idx(ea)
         ea, name = idaapi.get_nlist_ea(idx), idaapi.get_nlist_name(idx)
-        return ea, utils.string.of(name)
+        return idx, ea, utils.string.of(name)
 
 class search(object):
     """

--- a/base/database.py
+++ b/base/database.py
@@ -3251,12 +3251,12 @@ class type(object):
     @utils.multicase()
     @staticmethod
     def has_reference():
-        '''Return true if the current address has a reference.'''
+        '''Return if the current address is referencing another address.'''
         return type.has_reference(ui.current.address())
     @utils.multicase(ea=six.integer_types)
     @staticmethod
     def has_reference(ea):
-        '''Return true if the address at `ea` has a reference.'''
+        '''Return if the address at `ea` is referencing another address.'''
         return type.flags(interface.address.within(ea), idaapi.FF_REF) == idaapi.FF_REF
     referenceQ = refQ = utils.alias(has_reference, 'type')
 
@@ -3397,12 +3397,12 @@ class type(object):
     @utils.multicase()
     @staticmethod
     def is_reference():
-        '''Return true if the data at the current address is referenced.'''
+        '''Return if the data at the current address is referenced by another address.'''
         return type.is_reference(ui.current.address())
     @utils.multicase(ea=six.integer_types)
     @staticmethod
     def is_reference(ea):
-        '''Return true if the data at the address `ea` is referenced.'''
+        '''Return if the data at the address `ea` is referenced by another address.'''
         X, flags = idaapi.xrefblk_t(), idaapi.XREF_FAR | idaapi.XREF_DATA
         return X.first_to(ea, flags)
     is_ref = is_referenced = utils.alias(is_reference, 'type')
@@ -4026,7 +4026,7 @@ class marks(object):
         if 0 <= index < cls.MAX_SLOT_COUNT:
             return (cls.__get_slotaddress(index), cls.__get_description(index))
         raise E.IndexOutOfBoundsError(u"{:s}.by_index({:d}) : The specified mark slot index ({:d}) is out of bounds ({:s}).".format('.'.join((__name__, cls.__name__)), index, index, ("{:d} < 0".format(index)) if index < 0 else ("{:d} >= MAX_SLOT_COUNT".format(index))))
-    byIndex = utils.alias(by_index, 'marks')
+    byindex = utils.alias(by_index, 'marks')
 
     @utils.multicase()
     @classmethod
@@ -4038,7 +4038,7 @@ class marks(object):
     def by_address(cls, ea):
         '''Return the `(address, description)` of the mark at the given address `ea`.'''
         return cls.by_index(cls.__find_slotaddress(ea))
-    by = byAddress = utils.alias(by_address, 'marks')
+    by = byaddress = utils.alias(by_address, 'marks')
 
     ## Internal functions depending on which version of IDA is being used (<7.0)
     if idaapi.__version__ < 7.0:


### PR DESCRIPTION
This PR removes a number of definitions that were discovered to be duplicates, and removes some camelCased aliases as well as deprecated/unnecessary functions. The `names` and `imports` namespaces were also tweaked in order to better and more consistently extract the module name from their symbols. The `search` namespace was also significantly improved with a version that is compatible with Python3.

This closes issue #94, and is part of the prerequisites list at https://github.com/arizvisa/ida-minsc/pull/84#issuecomment-740769754. 