### PR TITLE
Updated the structure module to raise exceptions and logs events when unable to assign names or properties.

### DIFF
--- a/base/enumeration.py
+++ b/base/enumeration.py
@@ -209,10 +209,10 @@ def mask(enum):
 def repr(enum):
     '''Return a printable summary of the enumeration `enum`.'''
     eid = by(enum)
-    w = size(eid)*2
-    res = [(member.name(item), member.value(item), member.mask(item), member.comment(item)) for item in members.iterate(eid)]
+    w, cmt = 2 * size(eid), comment(enum, repeatable=True) or comment(enum, repeatable=False)
+    res = [(member.name(item), member.value(item), member.mask(item), member.comment(item, repeatable=True) or member.comment(item, repeatable=False)) for item in members.iterate(eid)]
     aligned = max([len(item) for item, _, _, _ in res] if res else [0])
-    return "<type 'enum'> {:s}\n".format(name(eid)) + '\n'.join(("[{:d}] {:<{align}s} : {:#0{width}x} & {:#0{width}x}".format(i, name, value, bmask, width=w+2, align=aligned)+((' // '+comment) if comment else '') for i,(name,value,bmask,comment) in enumerate(res)))   # XXX
+    return "<type 'enum'> {:s}{:s}\n".format(name(eid), " // {:s}".format(cmt) if cmt else '') + '\n'.join(("[{:d}] {:<{align}s} : {:#0{width}x} & {:#0{width}x}".format(i, name, value, bmask, width=w+2, align=aligned) + (" // {:s}".format(comment) if comment else '') for i,(name,value,bmask,comment) in enumerate(res)))
 
 __matcher__ = utils.matcher()
 __matcher__.attribute('index', idaapi.get_enum_idx)
@@ -453,6 +453,7 @@ class member(object):
     def parent(cls, mid):
         '''Return the id of the enumeration that owns the member `mid`.'''
         return idaapi.get_enum_member_enum(mid)
+    owner = utils.alias(parent, 'member')
 
     @utils.multicase(mid=six.integer_types)
     @classmethod

--- a/base/enumeration.py
+++ b/base/enumeration.py
@@ -181,16 +181,24 @@ def comment(enum, comment, **repeatable):
 
 @utils.multicase()
 def size(enum):
-    '''Return the number of bits for the enumeration `enum`.'''
+    '''Return the number of bytes for the enumeration `enum`.'''
     eid = by(enum)
-    res = idaapi.get_enum_width(eid)
-    return res * 8
+    return idaapi.get_enum_width(eid)
 @utils.multicase(width=six.integer_types)
 def size(enum, width):
-    '''Set the number of bits for the enumeration `enum` to `width`.'''
+    '''Set the number of bytes for the enumeration `enum` to `width`.'''
     eid = by(enum)
+    return idaapi.set_enum_width(eid, width)
+
+@utils.multicase()
+def bits(enum):
+    '''Return the number of bits for the enumeration `enum`.'''
+    return 8 * size(enum)
+@utils.multicase(width=six.integer_types)
+def bits(enum, width):
+    '''Set the number of bits for the enumeration `enum` to `width`.'''
     res = math.trunc(math.ceil(width / 8.0))
-    return idaapi.set_enum_width(eid, int(res))
+    return size(enum, int(res))
 
 def mask(enum):
     '''Return the bitmask for the enumeration `enum`.'''

--- a/base/structure.py
+++ b/base/structure.py
@@ -621,10 +621,18 @@ class structure_t(object):
         '''Remove the structure from the database.'''
         return idaapi.del_struc(self.ptr)
 
-    def __repr__(self):
+    def __str__(self):
         '''Display the structure in a readable format.'''
         name, offset, size, comment, tag = self.name, self.offset, self.size, self.comment or '', self.tag()
-        return "<class 'structure' name={!s}{:s} size={:#x}>{:s}".format(utils.string.repr(name), (" offset={:#x}".format(offset) if offset != 0 else ''), size, " // {!s}".format(utils.string.repr(tag) if '\n' in comment else comment.encode('utf8')) if comment else '')
+        return "<class 'structure' name={!s}{:s} size={:#x}>{:s}".format(utils.string.repr(name), (" offset={:#x}".format(offset) if offset != 0 else ''), size, " // {!s}".format(utils.string.repr(tag) if '\n' in comment else utils.string.to(comment)) if comment else '')
+
+    def __unicode__(self):
+        '''Display the structure in a readable format.'''
+        name, offset, size, comment, tag = self.name, self.offset, self.size, self.comment or '', self.tag()
+        return u"<class 'structure' name={!s}{:s} size={:#x}>{:s}".format(utils.string.repr(name), (" offset={:#x}".format(offset) if offset != 0 else ''), size, " // {!s}".format(utils.string.repr(tag) if '\n' in comment else utils.string.to(comment)) if comment else '')
+
+    def __repr__(self):
+        return u"{!s}".format(self)
 
     def field(self, offset):
         '''Return the member at the specified offset.'''
@@ -1354,7 +1362,7 @@ class members_t(object):
             return False
         return True
 
-    def __repr__(self):
+    def __str__(self):
         '''Display all the fields within the specified structure.'''
         res = []
         mn, ms, mti = 0, 0, 0
@@ -1370,8 +1378,30 @@ class members_t(object):
 
         if len(self):
             mo = max(map(len, map("{:x}".format, (self.baseoffset, self[-1].offset + self[-1].size))))
-            return "{!r}\n{:s}".format(self.parent, '\n'.join("[{:{:d}d}] {:>{:d}x}{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {!s} {:s}".format(i, mi, o, mo, s, ms, "{!s}".format(ti.dstr()).replace(' *','*'), mti, utils.string.repr(n), mn+2, utils.string.repr(t), " // {!s}".format(utils.string.repr(T) if '\n' in c else c.encode('utf8')) if c else '') for i, n, t, ti, o, s, c, T in res))
+            return "{!r}\n{:s}".format(self.parent, '\n'.join("[{:{:d}d}] {:>{:d}x}{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {!s} {:s}".format(i, mi, o, mo, s, ms, "{!s}".format(ti.dstr()).replace(' *','*'), mti, utils.string.repr(n), mn+2, utils.string.repr(t), " // {!s}".format(utils.string.repr(T) if '\n' in c else utils.string.to(c)) if c else '') for i, n, t, ti, o, s, c, T in res))
         return "{!r}".format(self.parent)
+
+    def __unicode__(self):
+        '''Display all the fields within the specified structure.'''
+        res = []
+        mn, ms, mti = 0, 0, 0
+        for i in six.moves.range(len(self)):
+            m = self[i]
+            name, t, ti, ofs, size, comment, tag = m.name, m.type, m.typeinfo, m.offset, m.size, m.comment, m.tag()
+            res.append((i, name, t, ti, ofs, size, comment or '', tag))
+            mn = max(mn, len(name))
+            ms = max(ms, len("{:+#x}".format(size)))
+            mti = max(mti, len("{!s}".format(ti.dstr()).replace(' *', '*')))
+
+        mi = len("{:d}".format(len(self) - 1)) if len(self) else 1
+
+        if len(self):
+            mo = max(map(len, map("{:x}".format, (self.baseoffset, self[-1].offset + self[-1].size))))
+            return u"{!r}\n{:s}".format(self.parent, '\n'.join("[{:{:d}d}] {:>{:d}x}{:<+#{:d}x} {:>{:d}s} {:<{:d}s} {!s} {:s}".format(i, mi, o, mo, s, ms, "{!s}".format(ti.dstr()).replace(' *','*'), mti, utils.string.repr(n), mn+2, utils.string.repr(t), " // {!s}".format(utils.string.repr(T) if '\n' in c else utils.string.to(c)) if c else '') for i, n, t, ti, o, s, c, T in res))
+        return u"{!r}".format(self.parent)
+
+    def __repr__(self):
+        return u"{!s}".format(self)
 
 class member_t(object):
     """
@@ -1713,10 +1743,18 @@ class member_t(object):
         cls = self.__class__
         raise E.DisassemblerError(u"{:s}({:#x}).typeinfo : Unable to assign typeinfo ({!s}) to structure member {:s} ({:s}).".format('.'.join((__name__, cls.__name__)), self.id, utils.string.repr(info), utils.string.repr(self.name), message))
 
-    def __repr__(self):
+    def __str__(self):
         '''Display the member in a readable format.'''
         id, name, typ, comment, tag, typeinfo = self.id, self.fullname, self.type, self.comment or '', self.tag(), "{!s}".format(self.typeinfo.dstr()).replace(' *', '*')
-        return "<member '{:s}' index={:d} offset={:-#x} size={:+#x}{:s}> {:s}".format(utils.string.escape(name, '\''), self.index, self.offset, self.size, " typeinfo='{:s}'".format(typeinfo) if len("{:s}".format(typeinfo)) else '', " // {!s}".format(utils.string.repr(tag) if '\n' in comment else comment.encode('utf8')) if comment else '')
+        return "<member '{:s}' index={:d} offset={:-#x} size={:+#x}{:s}> {:s}".format(utils.string.escape(name, '\''), self.index, self.offset, self.size, " typeinfo='{:s}'".format(typeinfo) if len("{:s}".format(typeinfo)) else '', " // {!s}".format(utils.string.repr(tag) if '\n' in comment else utils.string.to(comment)) if comment else '')
+
+    def __unicode__(self):
+        '''Display the member in a readable format.'''
+        id, name, typ, comment, tag, typeinfo = self.id, self.fullname, self.type, self.comment or '', self.tag(), "{!s}".format(self.typeinfo.dstr()).replace(' *', '*')
+        return u"<member '{:s}' index={:d} offset={:-#x} size={:+#x}{:s}> {:s}".format(utils.string.escape(name, '\''), self.index, self.offset, self.size, " typeinfo='{:s}'".format(typeinfo) if len("{:s}".format(typeinfo)) else '', " // {!s}".format(utils.string.repr(tag) if '\n' in comment else utils.string.to(comment)) if comment else '')
+
+    def __repr__(self):
+        return u"{!s}".format(self)
 
     def refs(self):
         """Return the `(address, opnum, type)` of all the code and data references to this member within the database.

--- a/base/structure.py
+++ b/base/structure.py
@@ -697,6 +697,10 @@ def comment(structure, **repeatable):
 def comment(structure, cmt, **repeatable):
     '''Set the comment to `cmt` for the specified `structure`.'''
     return comment(structure.id, cmt, **repeatable)
+@utils.multicase(structure=structure_t, none=types.NoneType)
+def comment(structure, none, **repeatable):
+    '''Remove the comment from the specified `structure`.'''
+    return comment(structure.id, none or '', **repeatable)
 @utils.multicase(id=six.integer_types, cmt=basestring)
 @utils.string.decorate_arguments('cmt')
 def comment(id, cmt, **repeatable):
@@ -706,6 +710,10 @@ def comment(id, cmt, **repeatable):
     """
     res = utils.string.to(cmt)
     return idaapi.set_struc_cmt(id, res, repeatable.get('repeatable', True))
+@utils.multicase(id=six.integer_types, none=types.NoneType)
+def comment(id, none, **repeatable):
+    '''Remove the comment from the structure identified by `id`.'''
+    return comment(id, none or '', **repeatable)
 
 @utils.multicase(id=six.integer_types)
 def index(id):


### PR DESCRIPTION
This PR updates the `structure` module so that when assigning a name or comment to one of the properties belonging to the `structure_t` or `member_t`, the assignment is actually validated. If the assignment completely fails, then an exception is raised. If the resulting assignment does not exactly correspond to what the user requested, then a log event is created. The enumeration module was also fixed so that any comments for an enumeration or its members are included in the result from the `enum.repr` function. 

This closes issue #88, and is part of the prerequisites list at https://github.com/arizvisa/ida-minsc/pull/84#issuecomment-740769754.