### PR TITLE
Updated the `instruction` module to check the number of operands prior to determining their result.

### DIFF
--- a/base/instruction.py
+++ b/base/instruction.py
@@ -102,7 +102,7 @@ def at(ea):
     '''Returns the ``idaapi.insn_t`` instance at the address `ea`.'''
     ea = interface.address.inside(ea)
     if not database.type.is_code(ea):
-        raise E.InvalidTypeOrValueError(u"{:s}.at({:#x}) : Unable to decode a non-instruction at specified address {:#x}.".format(__name__, ea, ea))
+        raise E.InvalidTypeOrValueError(u"{:s}.at({:#x}) : Unable to decode a non-instruction at the specified address ({:#x}).".format(__name__, ea, ea))
 
     # If we're using backwards-compatiblity mode (which means decode_insn takes
     # different parameters, then manage the result using idaapi.cmd
@@ -161,6 +161,9 @@ def mnemonic():
 def mnemonic(ea):
     '''Returns the mnemonic of the instruction at the address `ea`.'''
     ea = interface.address.inside(ea)
+    if not database.type.is_code(ea):
+        raise E.InvalidTypeOrValueError(u"{:s}.mnemonic({:#x}) : Unable to get the mnemonic for a non-instruction at the specified address ({:#x}).".format(__name__, ea, ea))
+
     res = (idaapi.ua_mnem(ea) or '').lower()
     return utils.string.of(res)
 mnem = utils.alias(mnemonic)

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -978,7 +978,12 @@ def op_structure(ea, opnum, path, **delta):
         insn = at(ea)
         ok = idaapi.op_stroff(insn, opnum, tid.cast(), length, moff + delta.get('delta', 0))
 
-    return True if ok else False
+    # if we were not successful at applying the structure, then raise an exception.
+    if not ok:
+        raise E.DisassemblerError(u"{:s}.op_structure({:#x}, {:d}, {!r}, delta={:d}) : Unable to apply the given structure path to the specified address ({:#x}).".format(__name__, ea, opnum, path, delta.get('delta', 0), ea))
+
+    # otherwise, we just chain into another case to return what was applied.
+    return op_structure(ea, opnum)
 op_struc = op_struct = utils.alias(op_structure)
 
 @utils.multicase(opnum=six.integer_types)


### PR DESCRIPTION
This PR adds a number of checks to the functions in the `instruction` module to ensure that a valid operand number was chosen. Checks were also added to the `mnemonic` function to ensure that it was only being used on valid code. The `instruction.op_refs` function was also fixed so that it would properly raise an exception when the chosen operand number is an enumeration, and the `instruction.op_structure` function will now always return a structure member path. 
 
This closes issue #98, and is part of the prerequisites list at https://github.com/arizvisa/ida-minsc/pull/84#issuecomment-740769754. 