### PR TITLE
Added some methods to the `ui.notepad` namespace which allows one to interact with the notepad window's contents.

### DIFF
--- a/misc/ui.py
+++ b/misc/ui.py
@@ -497,6 +497,63 @@ class notepad(appwindow):
     __open__ = staticmethod(idaapi.open_notepad_window)
     __open_defaults__ = ()
 
+    @classmethod
+    def open(cls, *args):
+        '''Open or show the notepad window and return its ``QtWidgets.QPlainTextEdit`` widget.'''
+        widget = super(notepad, cls).open(*args)
+        children = (item for item in widget.children() if isinstance(item, PyQt5.QtWidgets.QPlainTextEdit))
+        result = builtins.next(children, None)
+        if result is None:
+            raise internal.exceptions.ItemNotFoundError(u"{:s}.open({!s}) : Unable to locate the QtWidgets.QPlainTextEdit widget.".format('.'.join([__name__, cls.__name__]), ', '.join(map(internal.utils.repr, args))))
+        return result
+
+    @classmethod
+    def close(cls):
+        '''Close or hide the notepad window.'''
+        editor = cls.open()
+        widget = editor.parent()
+        return widget.deleteLater()
+
+    @classmethod
+    def get(cls):
+        '''Return the string that is currently stored within the notepad window.'''
+        editor = cls.open()
+        return editor.toPlainText()
+
+    @internal.utils.multicase(string=six.string_types)
+    @classmethod
+    def set(cls, string):
+        '''Set the text that is currently stored within the notepad window to `string`.'''
+        editor = cls.open()
+        return editor.setPlainText(string)
+
+    @internal.utils.multicase(items=(builtins.list, builtins.tuple))
+    @classmethod
+    def set(cls, items):
+        '''Set each line that is currently stored within the notepad window to `items`.'''
+        return cls.set('\n'.join(items))
+
+    @internal.utils.multicase(string=six.string_types)
+    @classmethod
+    def append(cls, string):
+        '''Append the provided `string` to the current text that is stored within the notepad window.'''
+        editor = cls.open()
+        return editor.appendPlainText(string)
+
+    @internal.utils.multicase()
+    @classmethod
+    def cursor(cls):
+        '''Return the ``QtGui.QTextCursor`` used by the notepad window.'''
+        editor = cls.open()
+        return editor.textCursor()
+
+    @internal.utils.multicase()
+    @classmethod
+    def cursor(cls, cursor):
+        '''Set the ``QtGui.QTextCursor`` for the notepad window to `cursor`.'''
+        editor = cls.open()
+        return editor.setTextCursor(cursor)
+
 class timer(object):
     """
     This namespace is for registering a python callable to a timer in IDA.


### PR DESCRIPTION
In a far away galaxy, the `notepad` namespace was added to the `ui` module. Unfortunately there were no useful methods that were included which would allow one to interact with the contents of the window which made this a pretty worthless namespace.

This PR re-implements the `notepad.open` function so that it will return the `QtWidgets.QPlainTextEdit` child by default which will allow someone to interact with it in its contents in its entirety. The `notepad.close` function was also implemented in order to contrast `notepad.open` by hiding it whenever the function is called.

A number of other functions were also implemented to interact with the context of the `QtWidgets.QPlainTextEdit` that is returned. This includes both getting and setting text with `notepad.get` and `notepad.set` (respectively), appending text (with `notepad.append`), and interacting with the `QtGui.QTextCursor` that is returned by using the `notepad.cursor` function.

This closes the long withstanding issue #10.