### PR TITLE
Updated the `structure` module to raise exceptions and log events if an api call has failed to set a property.

### DIFF
--- a/base/structure.py
+++ b/base/structure.py
@@ -564,7 +564,7 @@ class structure_t(object):
         ok = idaapi.expand_struc(self.ptr, 0, size - res, True)
         if not ok:
             cls = self.__class__
-            logging.fatal(u"{:s}({:#x}).size({:+d}) : Unable to resize structure \"{:s}\" from {:#x} bytes to {:#x} bytes.".format('.'.join([__name__, cls.__name__]), self.id, size, utils.string.escape(self.name, '"'), res, size))
+            raise E.DisassemblerError(u"{:s}({:#x}).size({:+d}) : Unable to resize structure \"{:s}\" from {:#x} bytes to {:#x} bytes.".format('.'.join([__name__, cls.__name__]), self.id, size, utils.string.escape(self.name, '"'), res, size))
         return res
 
     @property

--- a/base/structure.py
+++ b/base/structure.py
@@ -579,7 +579,15 @@ class structure_t(object):
     @index.setter
     def index(self, idx):
         '''Set the index of the structure to `idx`.'''
-        return idaapi.set_struc_idx(self.ptr, idx)
+        res = idaapi.get_struc_idx(self.id)
+        if not idaapi.set_struc_idx(self.ptr, idx):
+            cls = self.__class__
+            raise E.DisassemblerError(u"{:s}({:#x}).index({:+d}) : Unable to modify the index of structure \"{:s}\" from {:d} to index {:d}.".format('.'.join([__name__, cls.__name__]), self.id, idx, utils.string.escape(self.name, '"'), res, idx))
+
+        res = idaapi.get_struc_idx(self.id)
+        if res != idx:
+            logging.info(u"{:s}({:#x}).index({:+d}) : The index ({:d}) that the structure was moved to does not match what was requested ({:d}).".format('.'.join([__name__, cls.__name__]), self.id, idx, idx, res))
+        return res
 
     @property
     def typeinfo(self):

--- a/base/structure.py
+++ b/base/structure.py
@@ -481,13 +481,13 @@ class structure_t(object):
         oldname = idaapi.get_struc_name(self.id)
         if not idaapi.set_struc_name(self.id, ida_string):
             cls = self.__class__
-            raise E.DisassemblerError(u"{:s}({:#x}).name : Unable to assign the specified name ({:s}) to the structure {:s}.".format('.'.join([__name__, cls.__name__]), self.id, utils.string.repr(ida_string), utils.string.repr(oldname)))
+            raise E.DisassemblerError(u"{:s}({:#x}).name({!r}) : Unable to assign the specified name ({:s}) to the structure {:s}.".format('.'.join([__name__, cls.__name__]), self.id, string, utils.string.repr(ida_string), utils.string.repr(oldname)))
 
         # verify that the name was actually assigned properly
         assigned = idaapi.get_struc_name(self.id) or ''
         if utils.string.of(assigned) != utils.string.of(ida_string):
             cls = self.__class__
-            logging.info(u"{:s}({:#x}).name : The name ({:s}) that was assigned to the structure does not match what was requested ({:s}).".format('.'.join([__name__, cls.__name__]), self.id, utils.string.repr(utils.string.of(assigned)), utils.string.repr(ida_string)))
+            logging.info(u"{:s}({:#x}).name({!r}) : The name ({:s}) that was assigned to the structure does not match what was requested ({:s}).".format('.'.join([__name__, cls.__name__]), self.id, string, utils.string.repr(utils.string.of(assigned)), utils.string.repr(ida_string)))
         return assigned
 
     @property
@@ -1670,7 +1670,7 @@ class member_t(object):
         repeatable, res, state[key] = True, state.get(key, None), value
         if not idaapi.set_member_cmt(self.ptr, utils.string.to(internal.comment.encode(state)), repeatable):
             cls = self.__class__
-            raise E.DisassemblerError(u"{:s}({:#x}).comment : Unable to assign the provided comment to the structure member {:s}.".format('.'.join([__name__, cls.__name__]), self.id, utils.string.repr(self.name)))
+            raise E.DisassemblerError(u"{:s}({:#x}).comment(..., repeatable={!s}) : Unable to assign the provided comment to the structure member {:s}.".format('.'.join([__name__, cls.__name__]), self.id, repeatable, utils.string.repr(self.name)))
         return res
     @utils.multicase(key=six.string_types, none=None.__class__)
     @utils.string.decorate_arguments('key')


### PR DESCRIPTION
Previously when assigning a property or calling a setter function within the `structure` module, the result of the IDAPython API call was never checked. This resulted in assignments to a `structure_t` or `member_t` object failing silently. Some of these issues were actually mentioned in issue #96 (and solved by PR #97), but not all of them.

This PR goes through a number of the cases, refactors the way some of the API calls are made so that they're checked, and if they're being used to modify a property they are then compared against the value that was assigned. If the API call failed then an exception is raised, whereas if the API call did not assign exactly what the user requested then an logging event gets created.

This is related to PR #97, and closes issue #45.