### PR TITLE
Fixed an issue with reverse iteration of the netnode types in the `internal.netnode` module, and included a significant amount of documentation.

### DIFF
--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -195,7 +195,7 @@ class utils(object):
         return
     @classmethod
     def ralt(cls, node):
-        for item in cls.valriter(node, netnode.altfirst, netnode.altprev, netnode.altnext, netnode.altval):
+        for item in cls.valriter(node, netnode.altfirst, netnode.altlast, netnode.altprev, netnode.altval):
             yield item
         return
 
@@ -206,7 +206,7 @@ class utils(object):
         return
     @classmethod
     def rsup(cls, node):
-        for item in cls.valriter(node, netnode.supfirst, netnode.supprev, netnode.supnext, netnode.supval):
+        for item in cls.valriter(node, netnode.supfirst, netnode.suplast, netnode.supprev, netnode.supval):
             yield item
         return
 
@@ -217,7 +217,7 @@ class utils(object):
         return
     @classmethod
     def rhash(cls, node):
-        for item in cls.hriter(node, netnode.hashfirst, netnode.hashprev, netnode.hashnext, netnode.hashval):
+        for item in cls.hriter(node, netnode.hashfirst, netnode.hashlast, netnode.hashprev, netnode.hashval):
             yield item
         return
 
@@ -228,7 +228,7 @@ class utils(object):
         return
     @classmethod
     def rchar(cls, node):
-        for item in cls.valriter(node, netnode.charfirst, netnode.charprev, netnode.charnext, netnode.charval):
+        for item in cls.valriter(node, netnode.charfirst, netnode.charlast, netnode.charprev, netnode.charval):
             yield item
         return
 


### PR DESCRIPTION
The `internal.netnode` module is responsible for providing a number of utilities that are used to interact with a netnode within an IDA database. Most of the functionality within this module is designed to abstract iterating through the available types for a netnode. IDA actually provides ways for navigating forwards and backwards through these types which are also included by the module.

The `utils` namespace within the module provides wrappers for using IDAPython's API to iterate through all of the different types in both directions. The reverse direction, however, was being passed the wrong parameters which resulted in the functions not actually working. This PR fixes those incorrect parameters, and fully documents the module so that displaying the documentation with the `help` keyword actually works.

This closes issue #104.