### PR TITLE
Added special handling to the internal.netnode utilities when iterating through hash keys so that the empty key is supported properly despite its mishandling by IDAPython.

### DIFF
--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -617,7 +617,7 @@ class hash(object):
             l1, l2 = 0, 2
 
         for index, key in enumerate(cls.fiter(nodeidx)):
-            value = "{:<{:d}s} : default={!r}, memoryview={!r}, bytes={!r}, int={:#x}({:d})".format("{!r}".format(cls.get(nodeidx, key)), l2, cls.get(nodeidx, key, None), cls.get(nodeidx, key, memoryview), cls.get(nodeidx, key, bytes), cls.get(nodeidx, key, int), cls.get(nodeidx, key, int))
+            value = "{:<{:d}s} : default={!r}, bytes={!r}, int={:#x}({:d})".format("{!r}".format(cls.get(nodeidx, key)), l2, cls.get(nodeidx, key, None), cls.get(nodeidx, key, bytes), cls.get(nodeidx, key, int), cls.get(nodeidx, key, int))
             res.append("[{:d}] {:<{:d}s} -> {:s}".format(index, key, l1, value))
         if not res:
             raise internal.exceptions.MissingTypeOrAttribute(u"{:s}.repr({:#x}) : The specified node ({:x}) does not have any hashvals.".format('.'.join([__name__, cls.__name__]), nodeidx, nodeidx))

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -561,7 +561,7 @@ class hash(object):
             res = netnode.hashval(node, key)
             return res and memoryview(res)
         elif issubclass(type, bytes):
-            res = netnode.hashstr_buf(node, key)
+            res = netnode.hashval(node, key)
             return res and bytes(res)
         elif issubclass(type, six.string_types):
             return netnode.hashstr(node, key)
@@ -577,7 +577,7 @@ class hash(object):
         if isinstance(value, memoryview):
             return netnode.hashset(node, key, value.tobytes())
         elif isinstance(value, bytes):
-            return netnode.hashset_buf(node, key, value)
+            return netnode.hashset(node, key, value)
         elif isinstance(value, six.string_types):
             return netnode.hashset_buf(node, key, value)
         elif isinstance(value, six.integer_types):

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -184,22 +184,34 @@ class utils(object):
     def hfiter(cls, node, first, last, next, val):
         '''Iterate through all of the hash values for a netnode in order, and yield the (item, value) for each item that was found.'''
         start, end = first(node), last(node)
-        if val(node, start) is None: return
-        yield start, val(node, start)
+
+        # if start is not defined, its the same as end, and there's no value
+        # for the empty string...then there's no keys defined and we can leave.
+        if start is None and start == end and val(node, start or '') is None:
+            return
+
+        # otherwise, we start at the first item and continue on till the end.
+        yield start or '', val(node, start or '')
         while start != end:
-            start = next(node, start)
-            yield start, val(node, start)
+            start = next(node, start or '')
+            yield start or '', val(node, start or '')
         return
 
     @classmethod
     def hriter(cls, node, first, last, prev, val):
         '''Iterate through all of the hash values for a netnode in reverse order, and yield the (item, value) for each item that was found.'''
         start, end = first(node), last(node)
-        if val(node, end) is None: return
-        yield end, val(node, end)
+
+        # if end is not defined, its the same as start, and there's no value
+        # for the empty string...then there's no keys defined and we can leave.
+        if end is None and start == end and val(node, end or '') is None:
+            return
+
+        # otherwise, we start at the last item and continue on till the beginning.
+        yield end or '', val(node, end or '')
         while end != start:
-            end = prev(node, end)
-            yield end, val(node, end)
+            end = prev(node, end or '')
+            yield end or '', val(node, end or '')
         return
 
     @classmethod

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -195,7 +195,7 @@ class utils(object):
     def hriter(cls, node, first, last, prev, val):
         '''Iterate through all of the hash values for a netnode in reverse order, and yield the (item, value) for each item that was found.'''
         start, end = first(node), last(node)
-        if val(node, start) is None: return
+        if val(node, end) is None: return
         yield end, val(node, end)
         while end != start:
             end = prev(node, end)

--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -185,12 +185,15 @@ class utils(object):
         '''Iterate through all of the hash values for a netnode in order, and yield the (item, value) for each item that was found.'''
         start, end = first(node), last(node)
 
-        # if start is not defined, its the same as end, and there's no value
-        # for the empty string...then there's no keys defined and we can leave.
+        # If the start key is None, and it's the same as the end key, then we
+        # need to verify that there's no value stored for the empty key. If
+        # there's no value for the empty key, then we can be sure that there's
+        # no keys to iterate through and thus we can leave.
         if start is None and start == end and val(node, start or '') is None:
             return
 
-        # otherwise, we start at the first item and continue on till the end.
+        # Otherwise we need to start at the first item and continue fetching
+        # the next key until we end up at the last one.
         yield start or '', val(node, start or '')
         while start != end:
             start = next(node, start or '')
@@ -202,12 +205,15 @@ class utils(object):
         '''Iterate through all of the hash values for a netnode in reverse order, and yield the (item, value) for each item that was found.'''
         start, end = first(node), last(node)
 
-        # if end is not defined, its the same as start, and there's no value
-        # for the empty string...then there's no keys defined and we can leave.
+        # If the end key is None, and it's the same as the start key, then we
+        # need to verify that there's no value stored for the empty key. If
+        # there's no value for the empty key, then we can be sure that there's
+        # no keys to iterate through and thus we can leave.
         if end is None and start == end and val(node, end or '') is None:
             return
 
-        # otherwise, we start at the last item and continue on till the beginning.
+        # Otherwise we need to start at the last item and continue fetching the
+        # previous key until we end up at the first one.
         yield end or '', val(node, end or '')
         while end != start:
             end = prev(node, end or '')


### PR DESCRIPTION
IDAPython's netnode API provides a number of functions for enumerating the different types (supval, altval, and hashval) for a given netnode. These functions essentially provide the functionality to get the first, last, next, and previous values for the respective netnode type. When an error occurs within any of these functions, the `None` value is typically returned. Inside the `internal.netnode` module are a number of wrappers that are designed to simplify this interface, and make it consistent for all of the available types.

When iterating through the hashval type for a netnode, one would typically use `netnode.hashfirst` and `netnode.hashlast` to determine the start and end for all of the hashvals. Then to determine the items in between, the `netnode.hashnext` or `netnode.hashprev` would be used depending on whether the caller has chosen to start at the last hashval key, or the first hashval key. Thus the implementations of `utils.hfiter` and `utils.hriter` use each of these functions in a generic manner to yield each key along with the value of the key for every single available hashval in the netnode.

There's an issue, however, with IDAPython's implementation of `netnode.hashfirst` and `netnode.hashlast`. It seems that when an empty key is intended to be returned from either of these functions, the function will instead return `None`. As `None` is used to represent an error (or information that is missing), this results in the `utils.hfiter` and `utils.hriter` functions conidering that the netnode has no hashvals associated with it. I'm suspecting that this is because IDAPython (or whatever) is verifying that the key exists by checking for the hashval key's truthiness. As an empty string ('') is `False`, these APIs will instead return `None`.

To remedy this mishandling, rather than using `None` to check for an error, we prefix each iteration by checking to see if the start key (from `netnode.hashfirst`) is equivalent to the last key (from `netnode.hashlast`). If this is True and either of the keys are `None`, then the value for the empty string ('') is checked to see if it was defined. If if wasn't, then there really is no hashvals defined for the netnode, and we can terminate the iteration. Otherwise, if the empty string ('') has a value associated with it, then we ensure that we replace all instances of `None` with the empty string so that all the other logic should be the same.

This fixes issue #107.