### PR TITLE
Fixed some issues that would result in the incorrect API being used on older versions of IDA and would prevent some of the necessary hooks from working properly.

### DIFF
--- a/base/database.py
+++ b/base/database.py
@@ -89,7 +89,7 @@ class config(object):
     def __nw_init_info_structure__(cls, nw_code, is_old_database):
         logging.debug(u"{:s}.__nw_init_info_structure__({!s}) : Received notification to initialize information structure for database.".format('.'.join([__name__, cls.__name__]), ', '.join(map("{!r}".format, [nw_code, is_old_database]))))
         idp_modname = idaapi.get_idp_name()
-        return cls.__init_into_structure__(idp_modname)
+        return cls.__init_info_structure__(idp_modname)
 
     @classmethod
     def filename(cls):

--- a/base/database.py
+++ b/base/database.py
@@ -76,9 +76,17 @@ class config(object):
 
             # Display summary of the database and what it's used for.
             bits = "{:d}-bit".format(64 if information.is_64bit() else 32 if information.is_32bit() else 16)
-            byteorder = "{:s}-endian".format('big' if information.lflags & idaapi.LFLG_MSF else 'little')
-            mode = 'kernelspace' if information.lflags & idaapi.LFLG_KERNMODE else 'userspace'
             format = 'library' if information.lflags & idaapi.LFLG_IS_DLL else 'binary'
+
+            if idaapi.__version__ < 7.0:
+                byteorder = "{:s}-endian".format('big' if idaapi.cvar.inf.mf else 'little')
+            else:
+                byteorder = "{:s}-endian".format('big' if information.lflags & idaapi.LFLG_MSF else 'little')
+
+            if idaapi.__version__ >= 7.0:
+                mode = ' kernelspace' if information.lflags & idaapi.LFLG_KERNMODE else ' userspace'
+            else:
+                mode = ''
             logging.warning("Initialized {tag!s} database v{version:d} for {bits:s} {byteorder:s} {mode:s} {format:s}.".format('.'.join([information.__class__.__module__, information.__class__.__name__]), tag=information.tag, bits=bits, byteorder=byteorder, mode=mode, format=format, version=information.version))
 
         else:
@@ -137,6 +145,14 @@ class config(object):
             return True if cls.info.lflags & idaapi.LFLG_IS_DLL else False
         raise E.UnsupportedVersion(u"{:s}.is_sharedobject() : This function is only supported on versions of IDA 7.0 and newer.".format('.'.join([__name__, cls.__name__])))
     sharedobject = is_shared = sharedQ = utils.alias(is_sharedobject, 'config')
+
+    @classmethod
+    def is_kernelspace(cls):
+        '''Returns whether the database is using a kernelmode address space or not.'''
+        if idaapi.__version__ >= 7.0:
+            return True if cls.info.lflags & idaapi.LFLG_KERNMODE else False
+        raise E.UnsupportedVersion(u"{:s}.is_kernelspace() : This function is only supported on versions of IDA 7.0 and newer.".format('.'.join([__name__, cls.__name__])))
+    kernelspaceQ = utils.alias(is_kernelspace, 'config')
 
     @classmethod
     def changes(cls):

--- a/base/database.py
+++ b/base/database.py
@@ -76,9 +76,9 @@ class config(object):
 
             # Display summary of the database and what it's used for.
             bits = "{:d}-bit".format(64 if information.is_64bit() else 32 if information.is_32bit() else 16)
-            byteorder = "{:s}-endian".format('big' if information.is_be() else 'little')
-            mode = 'kernelspace' if information.is_kernel_mode() else 'userspace'
-            format = 'library' if information.is_dll() else 'binary'
+            byteorder = "{:s}-endian".format('big' if information.lflags & idaapi.LFLG_MSF else 'little')
+            mode = 'kernelspace' if information.lflags & idaapi.LFLG_KERNMODE else 'userspace'
+            format = 'library' if information.lflags & idaapi.LFLG_IS_DLL else 'binary'
             logging.warning("Initialized {tag!s} database v{version:d} for {bits:s} {byteorder:s} {mode:s} {format:s}.".format('.'.join([information.__class__.__module__, information.__class__.__name__]), tag=information.tag, bits=bits, byteorder=byteorder, mode=mode, format=format, version=information.version))
 
         else:
@@ -131,12 +131,12 @@ class config(object):
         raise E.UnsupportedVersion(u"{:s}.readonly() : This function is only supported on versions of IDA 7.0 and newer.".format('.'.join([__name__, cls.__name__])))
 
     @classmethod
-    def sharedobject(cls):
+    def is_sharedobject(cls):
         '''Returns whether the database is a shared-object or not.'''
         if idaapi.__version__ >= 7.0:
-            return cls.info.is_dll()
-        raise E.UnsupportedVersion(u"{:s}.sharedobject() : This function is only supported on versions of IDA 7.0 and newer.".format('.'.join([__name__, cls.__name__])))
-    is_sharedobject = sharedQ = sharedobject
+            return True if cls.info.lflags & idaapi.LFLG_IS_DLL else False
+        raise E.UnsupportedVersion(u"{:s}.is_sharedobject() : This function is only supported on versions of IDA 7.0 and newer.".format('.'.join([__name__, cls.__name__])))
+    sharedobject = is_shared = sharedQ = utils.alias(is_sharedobject, 'config')
 
     @classmethod
     def changes(cls):
@@ -197,7 +197,7 @@ class config(object):
         if idaapi.__version__ < 7.0:
             res = idaapi.cvar.inf.mf
             return 'big' if res else 'little'
-        return 'big' if cls.info.is_be() else 'little'
+        return 'big' if cls.info.lflags & idaapi.LFLG_MSF else 'little'
 
     @classmethod
     def main(cls):

--- a/base/function.py
+++ b/base/function.py
@@ -2047,7 +2047,7 @@ class type(object):
         # Guess the type information for the function ahead of time because
         # they should _always_ have type information associated with them.
         ti = idaapi.tinfo_t()
-        if idaapi.GUESS_FUNC_FAILED == idaapi.guess_tinfo(ea, ti) if idaapi.__version__ < 7.0 else idaapi.guess_tinfo(ti, ea):
+        if idaapi.GUESS_FUNC_FAILED == idaapi.guess_tinfo2(ea, ti) if idaapi.__version__ < 7.0 else idaapi.guess_tinfo(ti, ea):
             logging.info(u"{:s}({:#x}) : Ignoring failure ({:d}) when trying to determine `idaapi.tinfo_t()` for the specified function.".format('.'.join([__name__, cls.__name__]), idaapi.GUESS_FUNC_FAILED, ea))
 
         # If we can find a proper typeinfo then use that, otherwise return


### PR DESCRIPTION
In order for the plugin to provide a number of its capabilities to IDA, the plugin hooks many parts of IDA in order to track or transform itself according to what the user's needs might be. On newer versions of IDA, this is done with IDAPython's hooking capabilities. On older versions of IDA, however, this doesn't exist and so the plugin accomplishes its needs by using notification hooks. These notifications are not as granular as the regular hooks, but should get most things resolved.

When opening up a database, the plugin will hook processor selection via the `IDP_Hooks.ev_newprc` function. This way the plugin can swap its internal architecture state (representing registers and operand decoding) for the correct one depending on what processor IDA has selected. Since older versions of IDA don't provide this hook, we use a notification hook on the `NW_OPENIDB` notification with below-average priority which should allow the plugin to update its namespace so that its dependencies will also work properly.

As the hooks themselves are very similar, most of the wrapper hooks and notifications will simply call the actual hook after determining the correct parameters so that they can still work as they were originally intended. The `config.__nw_init_info_structure__` hook will actually call into the original `config.__init_info_structure__` after it has determined its parameters. Unfortunately, the implementation of that hook has misspelled the function that it calls into as `config.__init_into_structure__` and thus an exception will get raised and the plugin will fail to initialize its architecture for the loaded database.

This PR corrects that misspelling, and fixes a number of compatibility issues with the plugin on older versions of IDA. Another example of some of the other compatibility issues that needed to be fixed are the usage of the `idaapi.guess_tinfo` function which should be `idaapi.guess_tinfo2` on older versions of IDA as demonstrated in commit 7af2805b9d9d3a38d0b6065af4419e60917ab3d7. This same issue was discovered in the `function` module and was also fixed by this PR.

This intends to solve issue #106.