### PR TITLE
Implemented the `ui.keyboard.list` function and added better support for badly formatted input when using `ui.keyboard.map`.

### DIFF
--- a/misc/ui.py
+++ b/misc/ui.py
@@ -914,6 +914,11 @@ class keyboard(object):
         else:
             res = None
 
+        # Verify that the user gave us a callable to use to avoid mapping a
+        # useless type to the specified keyboard combination.
+        if not builtins.callable(callable):
+            raise internal.exceptions.InvalidTypeOrValueError(u"{:s}.map({!s}, {!r}) : Unable to map the non-callable value {!r} to the hotkey combination {!s}.".format('.'.join([__name__, cls.__name__]), internal.utils.string.repr(key), callable, callable, internal.utils.string.repr(keystring)))
+
         # Define a closure that calls the user's callable as it seems that IDA's
         # hotkey functionality doesn't deal too well when the same callable is
         # mapped to different hotkeys.

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -749,7 +749,7 @@ class keyboard(object):
     @classmethod
     def __of_key__(cls, key):
         '''Convert the normalized hotkey tuple in `key` into a format that IDA can comprehend.'''
-        Separators = {'-', '+', '_'}
+        Separators = {'-', '+'}
         Modifiers = {'ctrl', 'shift', 'alt'}
 
         # Validate the type of our parameter

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -814,6 +814,42 @@ class keyboard(object):
     __cache__ = {}
 
     @classmethod
+    def list(cls):
+        '''Display the current list of keyboard combinations that are mapped along with the callable each one is attached to.'''
+        maxkey, maxinfo = 0, 0
+
+        results = []
+        for mapping, (capsule, closure) in cls.__cache__.items():
+            key = cls.__of_key__(mapping)
+            information = internal.utils.multicase.prototype(closure)
+
+            # Now we can figure out the documentation for the closure that was stored.
+            documentation = closure.__doc__ or ''
+            if documentation:
+                filtered = [item.strip() for item in documentation.split('\n') if item.strip()]
+                header = next((item for item in filtered), '')
+                comment = "{:s}...".format(header) if header and len(filtered) > 1 else header
+            else:
+                comment = ''
+
+            # Calculate our maximum column widths inline
+            maxkey = max(maxkey, len(key))
+            maxinfo = max(maxinfo, len(information))
+
+            # Append each column to our results
+            results.append((key, information, comment))
+
+        # If we didn't aggregate any results, then raise an exception as there's nothing to do.
+        if not results:
+            raise internal.exceptions.SearchResultsError(u"{:s}.list() : Found 0 key combinations mapped.".format('.'.join([__name__, cls.__name__])))
+
+        # Now we can output what was mapped to the user.
+        six.print_(u"Found the following{:s} key combination{:s}:".format(" {:d}".format(len(results)) if len(results) > 1 else '', '' if len(results) == 1 else 's'))
+        for key, info, comment in results:
+            six.print_(u"Key: {:>{:d}s} -> {:<{:d}s}{:s}".format(key, maxkey, info, maxinfo, " // {:s}".format(comment) if comment else ''))
+        return
+
+    @classmethod
     def map(cls, key, callable):
         """Map the specified `key` combination to a python `callable` in IDA.
 

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -770,12 +770,24 @@ class keyboard(object):
         Separators = {'-', '+', '_'}
         Modifiers = {'ctrl', 'shift', 'alt'}
 
-        # First check to see if we were given a tuple. If so, then we might've
-        # been given a valid hotkey. However, we still need to validate this. So,
-        # to do that we'll concatenate each component together back into a string
+        # First check to see if we were given a tuple or list. If so, then we might
+        # have been given a valid hotkey. However, we still need to validate this.
+        # So, to do that we'll concatenate each component together back into a string
         # and then recurse so we can validate using the same logic.
-        if isinstance(hotkey, tuple):
-            modifiers, key = hotkey
+        if isinstance(hotkey, (tuple, list, set)):
+            try:
+                # If we were mistakenly given a set, then we need to reformat it.
+                if isinstance(hotkey, set):
+                    raise ValueError
+
+                modifiers, key = hotkey
+
+            # If the tuple we received was of an invalid format, then extract the
+            # modifiers that we can from it, and try again.
+            except ValueError:
+                modifiers = tuple(item for item in hotkey if item.lower() in Modifiers)
+                key = ''.join(item for item in hotkey if item.lower() not in Modifiers)
+
             separator = next(item for item in Separators)
 
             components = [item for item in modifiers] + [key]


### PR DESCRIPTION
When mapping keys via the `ui.keyboard` namespace, there isn't any way to display the currently mapped keys and thus it is up to the user to determine what is mapped versus unmapped. When using hundreds of macros (like I apparently do), this very quickly becomes unmanageable. This PR implements a `ui.keyboard.list` function which does its best to display the currently managed key combinations along with the type of the callable that the combination is mapped to.

This PR originated due to an issue which manifested itself when using Python3 with PR #84 that was due to the `ui.keyboard.__of_key__` function mistakenly using the '_' character as a separator which isn't valid for the `idaapi.add_hotkey` function. To remedy this, this separator was simply removed and the input for the `ui.keyboard.__normalize_key__` was made to be more forgiving when given the hotkey to remap. This was done by allowing the user to specify their keyboard mapping via a string (i.e. "ctrl+f"), a tuple in the correct form (i.e. `(('ctrl',), 'f')`), or a set/list/tuple that mixes up the modifiers and key combinations (i.e. `{'ctrl','f'}`, `('ctrl','f')`, or `['ctrl','alt','f']`).

A conditional was also added to the `ui.keyboard.map` function to ensure that a valid callable is passed. This allows reducing the amount of type-checking that is done when performing a `ui.keyboard.list` of all the current keyboard mappings.

This fixes issue #114.