### PR TITLE
Removed the checks against the current analysis pass from all function-related hooks so that they always execute and update their cache.

### DIFF
--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -779,8 +779,6 @@ def func_tail_appended(pfn, tail):
     We simply iterate through the new chunk, decrease all of its tags in the
     global context, and increase their reference within the function context.
     """
-    global State
-    if State != state.ready: return
     # tail = func_t
     for ea in database.address.iterate(interface.range.bounds(tail)):
         for k in database.tag(ea):
@@ -796,8 +794,6 @@ def removing_func_tail(pfn, tail):
     We simply iterate through the old chunk, decrease all of its tags in the
     function context, and increase their reference within the global context.
     """
-    global State
-    if State != state.ready: return
     # tail = range_t
     for ea in database.address.iterate(interface.range.bounds(tail)):
         for k in database.tag(ea):
@@ -813,8 +809,6 @@ def func_tail_removed(pfn, ea):
     We simply iterate through the old chunk, decrease all of its tags in the
     function context, and increase their reference within the global context.
     """
-    global State
-    if State != state.ready: return
 
     # first we'll grab the addresses from our refs
     listable = internal.comment.contents.address(ea, target=interface.range.start(pfn))
@@ -849,8 +843,6 @@ def tail_owner_changed(tail, owner_func):
     function's context.
     """
     # XXX: this is for older versions of IDA
-    global State
-    if State != state.ready: return
 
     # this is easy as we just need to walk through tail and add it
     # to owner_func

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -861,8 +861,6 @@ def add_func(pfn):
     from global tags to function tags. This iterates through each chunk belonging
     to the function and does exactly that.
     """
-    global State
-    if State != state.ready: return
 
     # convert all globals into contents
     for l, r in function.chunks(pfn):
@@ -884,8 +882,6 @@ def del_func(pfn):
     and then increasing it for the database. Afterwards we simply remove the
     reference count cache for the function.
     """
-    global State
-    if State != state.ready: return
 
     # convert all contents into globals
     for l, r in function.chunks(pfn):

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -906,11 +906,9 @@ def set_func_start(pfn, new_start):
     the function that was changed. Then we can update the reference count for
     any globals that were tagged by moving them into the function's tagcache.
     """
-    global State
-    if State != state.ready: return
 
-    # new_start has removed addresses from function
-    # replace contents with globals
+    # if new_start has removed addresses from function, then we need to transform
+    # all contents tags into globals tags
     if interface.range.start(pfn) > new_start:
         for ea in database.address.iterate(new_start, database.address.prev(interface.range.start(pfn))):
             for k in database.tag(ea):
@@ -920,8 +918,8 @@ def set_func_start(pfn, new_start):
             continue
         return
 
-    # new_start has added addresses to function
-    # replace globals with contents
+    # if new_start has added addresses to function, then we need to transform all
+    # its global tags into contents tags
     elif interface.range.start(pfn) < new_start:
         for ea in database.address.iterate(interface.range.start(pfn), database.address.prev(new_start)):
             for k in database.tag(ea):
@@ -939,10 +937,9 @@ def set_func_end(pfn, new_end):
     end of the function that was changed. Then we can update the reference count
     for any globals that were tagged by moving them into the function's tagcache.
     """
-    global State
-    if State != state.ready: return
-    # new_end has added addresses to function
-    # replace globals with contents
+
+    # if new_end has added addresses to function, then we need to transform
+    # all globals tags into contents tags
     if new_end > interface.range.end(pfn):
         for ea in database.address.iterate(interface.range.end(pfn), database.address.prev(new_end)):
             for k in database.tag(ea):
@@ -952,8 +949,8 @@ def set_func_end(pfn, new_end):
             continue
         return
 
-    # new_end has removed addresses from function
-    # replace contents with globals
+    # if new_end has removed addresses from function, then we need to transform
+    # all contents tags into globals tags
     elif new_end < interface.range.end(pfn):
         for ea in database.address.iterate(new_end, database.address.prev(interface.range.end(pfn))):
             for k in database.tag(ea):


### PR DESCRIPTION
When a database is being analyzed, the plugin hooks a variety of points in order to determine the address and comments that need to be cached. In order to improve performance, the plugin keeps track of the current analysis state within a global variable named `State` and uses it to determine whether certain hooks should be executed or not. This was done so that we could avoid duplication of work as some of the reference counting is re-performed when the entire function is being processed.

During the different stages of IDA's analysis, a function may go through various states of promotion and demotion as analysis is being performed. As the plugin is hooking various parts of this analysis, this would occasionally result in the plugin performing actions that are later undone by analysis. To work around this, the plugin would try to determine whether IDA had performed its first analysis yet, and avoid performing any real cache-updating work until the first analysis has been completed. This way no serious python has been executed until all of the functions have been processed and cached.

It was discovered that occasionally a reference count would end up being created for a function at the address of an SEH handler, or an arbitrary function chunk which would result in the address of the chunk being returned instead of the function when querying the database. Examining the cache showed that there was commonly a single reference existing at the wrong address which would affect querying. This was happening because of the different passes that IDA performs on a database. Many of these wrong addresses were actually being cached because of the `__name__` tag. During an earlier pass, the suspect address would be created as a function, and then in a later pass the address would either be demoted into a chunk for another function, or the address would be removed due to an analysis pass changing the boundaries of the chunk. This would result in a stray reference to the `__name__` tag still being cached.

Although it was intended that these tag references be updated during the process of executing a function, it turned out that the reason why the stray reference was left was because the name at the given address was transformed to a global and then back to a function later during analysis which would leave the name in the cache. The hook wasn't executing because it was only intended to execute once the database has completed its first analysis pass.

To fix this, all of the relevant hooks were modified to remove the block which checks whether the database has completed its analysis or not. This can have an affect on performance as now during IDA's analysis process python may execute, but with my tests it doesn't seem to be as big of a deal as it was when I first wrote these hooks. I imagine back then that the bugs in the hooks (that have since been fixed) were affecting performance, and that was why the block was originally necessary.

This fixes issue #117.