### PR TITLE
Updated the hook and notification objects to render the targets that are currently being used, and whether they're enabled or disabled.

### DIFF
--- a/base/_interface.py
+++ b/base/_interface.py
@@ -329,7 +329,7 @@ class prioritybase(object):
             # If a method is passed to us, then we need to extract all
             # of the relevant components that describe it.
             if isinstance(object, (types.MethodType, staticmethod, classmethod)):
-                cls = pycompat.method.type(object)
+                cls = pycompat.method.self(object)
                 func = pycompat.method.function(object)
                 module, name = func.__module__, pycompat.function.name(func)
                 iterable = parameters(func)

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -368,14 +368,14 @@ class prioritybase(object):
         res = ["{!s}".format(cls)]
 
         # First gather all our enabled hooks.
-        for target in self.enabled:
+        for target in sorted(self.enabled):
             items = self.__cache__[target]
             hooks = sorted([(priority, callable) for priority, callable in items], key=operator.itemgetter(0))
             items = ["{description:s}[{:+d}]".format(priority, description=name if args is None else "{:s}({:s})".format(name, ', '.join(args))) for priority, name, args in map(repr_prioritytuple, hooks)]
             res.append("{:<{:d}s} : {!s}".format(self.__formatter__(target), alignment_enabled, ' '.join(items)))
 
         # Now we can append all the disabled ones.
-        for target in self.disabled:
+        for target in sorted(self.disabled):
             items = self.__cache__[target]
             hooks = sorted([(priority, callable) for priority, callable in items], key=operator.itemgetter(0))
             items = ["{description:s}[{:+d}]".format(priority, description=name if args is None else "{:s}({:s})".format(name, ', '.join(args))) for priority, name, args in map(repr_prioritytuple, hooks)]
@@ -454,6 +454,7 @@ class prioritybase(object):
         # from our cache.
         else:
             self.__cache__.pop(target, [])
+            self.__disabled.discard(target)
 
         return True if found else False
 
@@ -673,7 +674,7 @@ class priorityhook(prioritybase):
         hType = hObject.__class__
         hName = hType.__name__
         if not self.available:
-            return "Hooks for {:s}: {:s}".format(hName, 'No hooks have been added')
+            return "Hooks for {:s}: {:s}".format(hName, 'No hooks have been added.')
         res, items = "Hooks for {:s}:".format(hName), super(priorityhook, self).__repr__().split('\n')
         return '\n'.join([res] + items[1:])
 
@@ -708,6 +709,12 @@ class prioritynotification(prioritybase):
             raise ValueError("{:s}.apply({:#x}): Unable to apply the specified notification ({:#x}) due to the value being invalid.".format('.'.join([__name__, cls.__name__]), notification, notification))
 
         return super(prioritynotification, self).apply(notification)
+
+    def __repr__(self):
+        if not self.available:
+            return "Notification events: {:s}".format('No hooks have been added.')
+        res, items = 'Notification events:', super(prioritynotification, self).__repr__().split('\n')
+        return '\n'.join([res] + items[1:])
 
 class address(object):
     """


### PR DESCRIPTION
This PR updates the `prioritybase` class in the `internal.interface` module so that it displays all of the targets that are hooked by the object, and displays each priority/callable pair that is associated with a given target. The enabled and disabled targets are emitted within their own sections, and the list of callables is sorted by priority.

To accomplish this, the `prioritybase` class had a few new properties added so that a user can ask the object what targets are enabled or disabled. Also, the `prioritynotification` class also had its formatter updated so that the notification targets are rendered according to the `idaapi.NW_*` enumeration from IDAPython.

During the implementation of this, a minor issue was discovered when removing the last target while it's disabled. This would result in the target not being completely removed from the cache. This was patched by ensuring that when the target is removed, any reference to the target in the disabled set is also removed.

This closes issue #123.