### PR TITLE
Updated both the hooks and tagfix modules to update the tag cache for any and all types of tags

### DIFF
--- a/custom/tagfix.py
+++ b/custom/tagfix.py
@@ -49,6 +49,30 @@ def fetch_contents(fn):
             for name in items:
                 addr[ea] = addr.get(ea, 0) + 1
                 tags[name] = tags.get(name, 0) + 1
+
+            # check if there's any extra comments so we can explicitly add those too.
+            eprefix = db.extra.__get_prefix__(ea)
+            if eprefix is not None:
+                addr[ea] = addr.get(ea, 0) + 1
+                tags['__extra_prefix__'] = tags.get('__extra_prefix__', 0) + 1
+
+            esuffix = db.extra.__get_suffix__(ea)
+            if esuffix is not None:
+                addr[ea] = addr.get(ea, 0) + 1
+                tags['__extra_suffix__'] = tags.get('__extra_suffix__', 0) + 1
+
+            # if there's any colors, then we need to do those.
+            col = db.color(ea)
+            if col is not None:
+                addr[ea] = addr.get(ea, 0) + 1
+                tags['__color__'] = tags.get('__color__', 0) + 1
+
+            # finally if there's any names that're part of this global,
+            # then we add them too.
+            aname = db.name(ea)
+            if aname and db.type.flags(ea, idaapi.FF_NAME):
+                addr[ea] = addr.get(ea, 0) + 1
+                tags['__name__'] = tags.get('__name__', 0) + 1
             continue
         continue
     return func.address(fn), addr, tags

--- a/custom/tagfix.py
+++ b/custom/tagfix.py
@@ -102,6 +102,30 @@ def fetch_globals_data():
                 addr[ea] = addr.get(ea, 0) + 1
                 tags[name] = tags.get(name, 0) + 1
             continue
+
+        # check if there's any extra comments so we can explicitly add those too.
+        eprefix = db.extra.__get_prefix__(ea)
+        if eprefix is not None:
+            addr[ea] = addr.get(ea, 0) + 1
+            tags['__extra_prefix__'] = tags.get('__extra_prefix__', 0) + 1
+
+        esuffix = db.extra.__get_suffix__(ea)
+        if esuffix is not None:
+            addr[ea] = addr.get(ea, 0) + 1
+            tags['__extra_suffix__'] = tags.get('__extra_suffix__', 0) + 1
+
+        # if there's any colors, then we need to do those.
+        col = db.color(ea)
+        if col is not None:
+            addr[ea] = addr.get(ea, 0) + 1
+            tags['__color__'] = tags.get('__color__', 0) + 1
+
+        # finally if there's any names that're part of this global,
+        # then we add them too.
+        aname = db.name(ea)
+        if aname and db.type.flags(ea, idaapi.FF_NAME):
+            addr[ea] = addr.get(ea, 0) + 1
+            tags['__name__'] = tags.get('__name__', 0) + 1
         continue
     return addr, tags
 

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -49,7 +49,12 @@ class commentbase(object):
     @classmethod
     def is_ready(cls):
         global State
-        return State == state.ready
+        return State in {state.ready}
+
+    @classmethod
+    def is_loaded(cls):
+        global State
+        return State in {state.loaded, state.ready}
 
 class address(commentbase):
     @classmethod
@@ -160,8 +165,8 @@ class address(commentbase):
 
     @classmethod
     def changing(cls, ea, repeatable_cmt, newcmt):
-        if not cls.is_ready():
-            return logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Ignoring comment.changing event (database not ready) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
+        if not cls.is_loaded():
+            return logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Ignoring comment.changing event (database not loaded) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
 
         # Grab our old comment, because we're going to submit this later to a coro
         logging.debug(u"{:s}.changing({:#x}, {:d}, {!s}) : Received comment.changing event for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, repeatable_cmt, utils.string.repr(newcmt), 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
@@ -191,8 +196,8 @@ class address(commentbase):
 
     @classmethod
     def changed(cls, ea, repeatable_cmt):
-        if not cls.is_ready():
-            return logging.debug(u"{:s}.changed({:#x}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
+        if not cls.is_loaded():
+            return logging.debug(u"{:s}.changed({:#x}, {:d}) : Ignoring comment.changed event (database not loaded) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
 
         # Grab our new comment, because we're going to submit this later to our coro
         logging.debug(u"{:s}.changed({:#x}, {:d}) : Received comment.changed event for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, repeatable_cmt, 'repeatable' if repeatable_cmt else 'non-repeatable', ea))
@@ -349,8 +354,8 @@ class globals(commentbase):
 
     @classmethod
     def changing(cls, cb, a, cmt, repeatable):
-        if not cls.is_ready():
-            return logging.debug(u"{:s}.changing({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changing event (database not ready) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+        if not cls.is_loaded():
+            return logging.debug(u"{:s}.changing({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changing event (database not loaded) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
 
         # First we'll check to see if this is an actual function comment by confirming
         # that we're in a function, and that our comment is not empty.
@@ -387,8 +392,8 @@ class globals(commentbase):
 
     @classmethod
     def changed(cls, cb, a, cmt, repeatable):
-        if not cls.is_ready():
-            return logging.debug(u"{:s}.changed({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changed event (database not ready) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
+        if not cls.is_loaded():
+            return logging.debug(u"{:s}.changed({!s}, {:#x}, {!s}, {:d}) : Ignoring comment.changed event (database not loaded) for a {:s} comment at {:#x}.".format('.'.join([__name__, cls.__name__]), utils.string.repr(cb), interface.range.start(a), utils.string.repr(cmt), repeatable, 'repeatable' if repeatable else 'non-repeatable', interface.range.start(a)))
 
         # First we'll check to see if this is an actual function comment by confirming
         # that we're in a function, and that our comment is not empty.


### PR DESCRIPTION
This PR modifies the `custom.tagfix` and `hooks` modules to ensure that all implicit tags are being written to the tag cache.

Specifically, the `hooks` module will now treat the database being initialized as it being ready which results in any name changes or comments that are made by IDA when it's performing its analysis being written to the tag cache. This might affect performance slightly, but it's unnoticable on my box with reasonably sized databases (but I'm not testing it against something like acrord or mso). The `custom.tagfix` module has also been specifically updated to crawl the `__extra_prefix__`, `__color__`, and `__name__` tags when processing both function contents and globals.

This results in the `hooks` grabbing almost all of the tags, but misses the "extra" comments that are represented by the `__extra_prefix__` and `__extra_suffix__` tags. I didn't spend too much time on this, but I figure that these aren't being identified correctly because Ilfak didn't describe the "extra" comment hooks with the same semantics as the regular comments ("comment changing" versus "comment changed").

This fix is one of the proposed solutions to issue #122.