### PR TITLE
Added more hooks in order to support the inclusion of more implicit tags in the tag cache, and added a workaround for the situation where a "changing_ti" event is dispatched without its related "ti_changed" event properly following it.

### DIFF
--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -33,7 +33,12 @@ def greeting():
     six.print_('-' * barrier)
 
 ### comment hooks
-class commentbase(object):
+class changebase(object):
+    """
+    This base class is for dealing with 2-part events where one part is the
+    "changing" event which is dispatched before any changes are made, and the
+    second part is the "changed" event which happens after they've been completed.
+    """
     @classmethod
     def database_init(cls, idp_modname):
         if hasattr(cls, 'event'):
@@ -51,7 +56,12 @@ class commentbase(object):
         global State
         return State == state.ready
 
-class address(commentbase):
+class address(changebase):
+    """
+    This class handles 2-part events that are used to modify comments at an arbitrary
+    address. This address will either be a contents tag if it's within the boundaries
+    of a function, or a globals tag if it's just some arbitrary address.
+    """
     @classmethod
     def get_func_extern(cls, ea):
         """Return the function at the given address and whether the address is a function populated by the rtld (an external).
@@ -261,7 +271,13 @@ class address(commentbase):
         # and then leave because this should've updated things properly.
         return
 
-class globals(commentbase):
+class globals(changebase):
+    """
+    This class handles 2-part events that are used to modify comments for a particular
+    range. In most cases this should be a function comment, or a chunk associated
+    with a function, but just to be certain we check the start_ea of the range
+    to determine whether we update the global or content tag cache.
+    """
     @classmethod
     def _update_refs(cls, fn, old, new):
         oldkeys, newkeys = ({item for item in content.keys()} for content in [old, new])

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -1202,8 +1202,10 @@ def make_ida_not_suck_cocks(nw_code):
     ## setup default integer types for the typemapper once the loader figures everything out
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_newprc', interface.typemap.__ev_newprc__, 0)
+
     elif idaapi.__version__ >= 6.9:
         ui.hook.idp.add('newprc', interface.typemap.__newprc__, 0)
+
     else:
         idaapi.__notification__.add(idaapi.NW_OPENIDB, interface.typemap.__nw_newprc__, -40)
 
@@ -1229,8 +1231,10 @@ def make_ida_not_suck_cocks(nw_code):
     ## create the tagcache netnode when a database is created
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_init', comment.tagging.__init_tagcache__, -1)
+
     elif idaapi.__version__ >= 6.9:
         ui.hook.idp.add('init', comment.tagging.__init_tagcache__, -1)
+
     else:
         idaapi.__notification__.add(idaapi.NW_OPENIDB, comment.tagging.__nw_init_tagcache__, -40)
 
@@ -1240,25 +1244,30 @@ def make_ida_not_suck_cocks(nw_code):
         ui.hook.idp.add('ev_init', globals.database_init, 0)
         ui.hook.idb.add('changing_range_cmt', globals.changing, 0)
         ui.hook.idb.add('range_cmt_changed', globals.changed, 0)
+
     elif idaapi.__version__ >= 6.9:
         ui.hook.idp.add('init', address.database_init, 0)
         ui.hook.idp.add('init', globals.database_init, 0)
         ui.hook.idb.add('changing_area_cmt', globals.changing, 0)
         ui.hook.idb.add('area_cmt_changed', globals.changed, 0)
+
     else:
         idaapi.__notification__.add(idaapi.NW_OPENIDB, address.nw_database_init, -30)
         idaapi.__notification__.add(idaapi.NW_OPENIDB, globals.nw_database_init, -30)
         ui.hook.idb.add('area_cmt_changed', globals.old_changed, 0)
 
+    # hook the changing of a comment
     if idaapi.__version__ >= 6.9:
         ui.hook.idb.add('changing_cmt', address.changing, 0)
         ui.hook.idb.add('cmt_changed', address.changed, 0)
+
     else:
         ui.hook.idb.add('cmt_changed', address.old_changed, 0)
 
     ## hook naming and "extra" comments to support updating the implicit tags
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_rename', rename, 0)
+
     else:
         ui.hook.idp.add('rename', rename, 0)
 
@@ -1269,9 +1278,11 @@ def make_ida_not_suck_cocks(nw_code):
         ui.hook.idb.add('deleting_func', del_func, 0)
         ui.hook.idb.add('set_func_start', set_func_start, 0)
         ui.hook.idb.add('set_func_end', set_func_end, 0)
+
     elif idaapi.__version__ >= 6.9:
         ui.hook.idb.add('removing_func_tail', removing_func_tail, 0)
         [ ui.hook.idp.add(item.__name__, item, 0) for item in [add_func, del_func, set_func_start, set_func_end] ]
+
     else:
         ui.hook.idb.add('func_tail_removed', func_tail_removed, 0)
         ui.hook.idp.add('add_func', add_func, 0)
@@ -1283,6 +1294,7 @@ def make_ida_not_suck_cocks(nw_code):
     ## rebase the entire tagcache when the entire database is rebased.
     if idaapi.__version__ >= 6.9:
         ui.hook.idb.add('allsegs_moved', rebase, 0)
+
     else:
         ui.hook.idb.add('segm_start_changed', segm_start_changed, 0)
         ui.hook.idb.add('segm_end_changed', segm_end_changed, 0)
@@ -1291,8 +1303,10 @@ def make_ida_not_suck_cocks(nw_code):
     ## switch the instruction set when the processor is switched
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_newprc', instruction.__ev_newprc__, 0)
+
     elif idaapi.__version__ >= 6.9:
         ui.hook.idp.add('newprc', instruction.__newprc__, 0)
+
     else:
         idaapi.__notification__.add(idaapi.NW_OPENIDB, instruction.__nw_newprc__, -10)
 
@@ -1300,8 +1314,10 @@ def make_ida_not_suck_cocks(nw_code):
     ## necessary and used by the processor detection.
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_init', database.config.__init_info_structure__, -100)
+
     elif idaapi.__version__ >= 6.9:
         ui.hook.idp.add('init', database.config.__init_info_structure__, -100)
+
     else:
         idaapi.__notification__.add(idaapi.NW_OPENIDB, database.config.__nw_init_info_structure__, -30)
 
@@ -1309,6 +1325,8 @@ def make_ida_not_suck_cocks(nw_code):
     if idaapi.__version__ >= 7.2:
         ui.hook.idb.add('item_color_changed', item_color_changed, 0)
 
+    # anything earlier than v7.0 doesn't expose the "changing_ti" and "ti_changed"
+    # hooks, so there's no actual need to hook "init" to support v6.9.
     if idaapi.__version__ >= 7.0:
         ui.hook.idp.add('ev_init', typeinfo.database_init, 0)
         ui.hook.idb.add('changing_ti', typeinfo.changing, 0)
@@ -1327,7 +1345,9 @@ def make_ida_not_suck_cocks(nw_code):
     #ui.hook.idb.add('allsegs_moved', notify('allsegs_moved'), -100)
     #[ ui.hook.idb.add(item, notify(item), -100) for item in ['cmt_changed', 'changing_cmt', 'range_cmt_changed', 'changing_range_cmt'] ]
     #[ ui.hook.idb.add(item, notify(item), -100) for item in ['changing_ti', 'ti_changed', 'changing_op_type', 'op_type_changed'] ]
-    #[ ui.hook.idb.add(item, notify(item), -100op_type_changed for item in ['changing_op_ti', 'op_ti_changed'] ]
+    #[ ui.hook.idb.add(item, notify(item), -100) for item in ['changing_op_ti', 'op_ti_changed'] ]
+    #ui.hook.idb.add('item_color_changed', notify(item), -100)
+    #ui.hook.idb.add('extra_cmt_changed', notify(item), -100)
 
     ### ...and that's it for all the hooks, so give out our greeting
     return greeting()

--- a/misc/hooks.py
+++ b/misc/hooks.py
@@ -485,6 +485,8 @@ class typeinfo(changebase):
     def changing(cls, ea, new_type, new_fname):
         if not cls.is_ready():
             return logging.debug(u"{:s}.changing({:#x}, {!s}, {!s}) : Ignoring typeinfo.changing event (database not ready) with new type ({!s}) and new name ({!s}) at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(new_type), utils.string.repr(new_fname), new_type, new_fname, ea))
+        if interface.node.is_identifier(ea):
+            return logging.debug(u"{:s}.changing({:#x}, {!s}, {!s}) : Ignoring typeinfo.changing event (not an address) with new type ({!s}) and new name ({!s}) at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(new_type), utils.string.repr(new_fname), new_type, new_fname, ea))
         logging.debug(u"{:s}.changing({:#x}, {!s}, {!s}) : Received typeinfo.changing for new_type ({!s}) and new_fname ({!s}).".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(new_type), utils.string.repr(new_fname), new_type, new_fname))
 
         # Extract the previous type information from the given address. If none
@@ -511,7 +513,7 @@ class typeinfo(changebase):
         # coroutine has gone out of sync and we need to reinitialize it in order
         # to regain control.
         except StopIteration as E:
-            logging.fatal(u"{:s}.changed({:#x}, {!s}, {!s}) : Unexpected termination of event handler. Re-instantiating it.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(type), utils.string.repr(fnames)))
+            logging.fatal(u"{:s}.changed({:#x}, {!s}, {!s}) : Unexpected termination of event handler. Re-instantiating it.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(new_type), utils.string.repr(new_fname)))
             cls.event = cls._event(); next(cls.event)
 
         # Last thing to do is to re-enable the hooks that we disabled and then leave.
@@ -523,6 +525,8 @@ class typeinfo(changebase):
     def changed(cls, ea, type, fnames):
         if not cls.is_ready():
             return logging.debug(u"{:s}.changed({:#x}, {!s}, {!s}) : Ignoring typeinfo.changed event (database not ready) with type ({!s}) and name ({!s}) at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(type), utils.string.repr(fnames), type, fnames, ea))
+        if interface.node.is_identifier(ea):
+            return logging.debug(u"{:s}.changed({:#x}, {!s}, {!s}) : Ignoring typeinfo.changed event (not an address) with type ({!s}) and name ({!s}) at {:#x}.".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(type), utils.string.repr(fnames), type, fnames, ea))
         logging.debug(u"{:s}.changed({:#x}, {!s}, {!s}) : Received typeinfo.changed event with type ({!s}) and name ({!s}).".format('.'.join([__name__, cls.__name__]), ea, utils.string.repr(type), utils.string.repr(fnames), type, fnames))
 
         # Take the data that IDA told us was written, and pack into a tuple so


### PR DESCRIPTION
This PR adds more hooks in order to catch when more of the hidden tags are modified by a user. This includes colors (`__color__`), and type info (`__typeinfo__`). When any of these are changed by a user, the tag cache will be updated with the user's changes. This should allow more ways for a user to query the parts of a database that they've visited before.

The hook to track the "extra" comments tags, `__extra_prefix__` and `__extra_suffix__`, has been reimplemented so that it's not a noop. Instead of tracking each individual extra comment index, it was rewritten to only check if the base index (`idaapi.E_PREV` or `idaapi.E_NEXT`) exists or not. This way we can guarantee that the tag is removed from the cache when the comment itself is removed. This unfortunately means that when "extra" comments are updated (as opposed to added or removed), and the modification has no change in the number of lines, we end up losing track of the refcount, and its address may remain permanently in the cache.

While testing this, I encountered another issue related to the "changing_ti" event being sent without its "ti_changed" partner. I was able to figure out a workaround that seems to work for most situations, but it's definitely pretty hacky. I'm considering refactoring this at the cost of potential memory loss, but I'll submit that in a separate PR.

This is one of the other solutions to issue #122.