### PR TITLE
Fixed all the precision issues with any logarithm calculations that are used to determine the number of digits for various bases.

### DIFF
--- a/__root__.py
+++ b/__root__.py
@@ -26,8 +26,8 @@ def __version__():
     major, minor = map(int, res.split('.', 2))
     minor = int("{:<02d}".format(minor))
     if minor > 0:
-        count = math.floor(1 + math.log10(minor))
-        return major, minor, float(major) + minor / pow(10, count)
+        count = 1 + math.floor(math.log10(minor))
+        return major, minor, float(major) + minor * pow(10, -count)
     return major, minor, float(major)
 
 ## inject the version info into idaapi

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -948,7 +948,7 @@ class node(object):
     @staticmethod
     def is_identifier(identifier):
         '''Return truth if the specified `identifier` is valid.'''
-        bits = math.floor(1 + math.log(idaapi.BADADDR) / math.log(2.))
+        bits = math.ceil(math.log(idaapi.BADADDR, 2.))  # this doesn't work on all bases due to python precision
         mask = 0xff * pow(2, math.trunc(bits) - 8)
         return identifier & mask == mask
 

--- a/base/enumeration.py
+++ b/base/enumeration.py
@@ -205,7 +205,7 @@ def mask(enum):
     '''Return the bitmask for the enumeration `enum`.'''
     eid = by(enum)
     res = bits(eid)
-    return 2 ** res - 1
+    return pow(2, res) - 1
 
 def repr(enum):
     '''Return a printable summary of the enumeration `enum`.'''
@@ -254,7 +254,7 @@ def list(**type):
     maxindex = max(builtins.map(idaapi.get_enum_idx, res) if res else [1])
     maxname = max(builtins.map(utils.fcompose(idaapi.get_enum_name, len), res) if res else [0])
     maxsize = max(builtins.map(size, res) if res else [0])
-    cindex = math.floor(1 + math.log10(maxindex or 1))
+    cindex = 1 + math.floor(math.log10(maxindex or 1))
     try: cmask = max(len("{:x}".format(mask(item))) for item in res) if res else database.config.bits() / 4.0
     except Exception: cmask = 0
 

--- a/base/instruction.py
+++ b/base/instruction.py
@@ -514,7 +514,7 @@ def op_number(ea, opnum):
 
     # Extract the operand's op_t and its maximum value, as we'll use this to
     # transform the value if necessary.
-    res, max = operand(ea, opnum), 2 ** op_bits(ea, opnum)
+    res, max = operand(ea, opnum), pow(2, op_bits(ea, opnum))
 
     # If this is an immediate value, then we can treat it normally.
     if res.type in {idaapi.o_imm}:
@@ -523,7 +523,7 @@ def op_number(ea, opnum):
 
     # If the signed-flag is set in our operand, then convert it into its actual
     # signed value.
-    maximum = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+    maximum = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
     integer = (res.addr - maximum) if res.addr & (maximum // 2) else res.addr
 
     # Now we can return the value transformed if the operand has an inverted sign
@@ -544,7 +544,7 @@ def op_character(ea, opnum):
 
     # Extract the operand's op_t and its maximum value, as we'll use this to
     # transform the value if necessary.
-    res, max = operand(ea, opnum), 2 ** op_bits(ea, opnum)
+    res, max = operand(ea, opnum), pow(2, op_bits(ea, opnum))
 
     # If this is an immediate value, then we can treat it normally.
     if res.type in {idaapi.o_imm}:
@@ -554,7 +554,7 @@ def op_character(ea, opnum):
     # If the signed-flag is set in our operand, then convert it into its actual
     # signed value.
     else:
-        maximum = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+        maximum = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
         integer = (res.addr - maximum) if res.addr & (maximum // 2) else res.addr
 
         # Now we can use the value transformed if the operand has an inverted sign
@@ -590,7 +590,7 @@ def op_binary(ea, opnum):
 
     # Extract the operand's op_t and its maximum value, as we'll use this to
     # transform the value if necessary.
-    res, max = operand(ea, opnum), 2 ** op_bits(ea, opnum)
+    res, max = operand(ea, opnum), pow(2, op_bits(ea, opnum))
 
     # If this is an immediate value, then we can treat it normally.
     if res.type in {idaapi.o_imm}:
@@ -599,7 +599,7 @@ def op_binary(ea, opnum):
 
     # If the signed-flag is set in our operand, then convert it into its actual
     # signed value.
-    maximum = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+    maximum = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
     integer = (res.addr - maximum) if res.addr & (maximum // 2) else res.addr
 
     # Now we can return the value transformed if the operand has an inverted sign
@@ -620,7 +620,7 @@ def op_octal(ea, opnum):
 
     # Extract the operand's op_t and its maximum value, as we'll use this to
     # transform the value if necessary.
-    res, max = operand(ea, opnum), 2 ** op_bits(ea, opnum)
+    res, max = operand(ea, opnum), pow(2, op_bits(ea, opnum))
 
     # If this is an immediate value, then we can treat it normally.
     if res.type in {idaapi.o_imm}:
@@ -629,7 +629,7 @@ def op_octal(ea, opnum):
 
     # If the signed-flag is set in our operand, then convert it into its actual
     # signed value.
-    maximum = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+    maximum = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
     integer = (res.addr - maximum) if res.addr & (maximum // 2) else res.addr
 
     # Now we can return the value transformed if the operand has an inverted sign
@@ -650,7 +650,7 @@ def op_decimal(ea, opnum):
 
     # Extract the operand's op_t and its maximum value, as we'll use this to
     # transform the value if necessary.
-    res, max = operand(ea, opnum), 2 ** op_bits(ea, opnum)
+    res, max = operand(ea, opnum), pow(2, op_bits(ea, opnum))
 
     # If this is an immediate value, then we can treat it normally.
     if res.type in {idaapi.o_imm}:
@@ -659,7 +659,7 @@ def op_decimal(ea, opnum):
 
     # If the signed-flag is set in our operand, then convert it into its actual
     # signed value.
-    maximum = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+    maximum = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
     integer = (res.addr - maximum) if res.addr & (maximum // 2) else res.addr
 
     # Now we can return the value transformed if the operand has an inverted sign
@@ -680,7 +680,7 @@ def op_hexadecimal(ea, opnum):
 
     # Extract the operand's op_t and its maximum value, as we'll use this to
     # transform the value if necessary.
-    res, max = operand(ea, opnum), 2 ** op_bits(ea, opnum)
+    res, max = operand(ea, opnum), pow(2, op_bits(ea, opnum))
 
     # If this is an immediate value, then we can treat it normally.
     if res.type in {idaapi.o_imm}:
@@ -689,7 +689,7 @@ def op_hexadecimal(ea, opnum):
 
     # If the signed-flag is set in our operand, then convert it into its actual
     # signed value.
-    maximum = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+    maximum = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
     integer = (res.addr - maximum) if res.addr & (maximum // 2) else res.addr
 
     # Now we can return the value transformed if the operand has an inverted sign
@@ -772,12 +772,12 @@ def op_structure(ea, opnum):
 
     # Figure out the offset for the structure member if it's an immediate value
     if op.type in {idaapi.o_imm}:
-        max = 2 ** op_bits(ea, opnum)
+        max = pow(2, op_bits(ea, opnum))
         offset = op.value & (max - 1)
 
     # Otherwise, this could be a signed operand and it needs to be converted.
     else:
-        max = math.trunc(2 ** math.ceil(math.log(idaapi.BADADDR, 2)))
+        max = pow(2, math.ceil(math.log(idaapi.BADADDR, 2.)))
         offset = (op.addr - max) if op.addr & (max // 2) else op.addr
 
     # Check to see if this is a stack variable, because we'll need to
@@ -1468,10 +1468,10 @@ class operand_types:
             bits = 8 * get_dtype_size(get_dtype_attribute(op))
 
             # figure out the sign flag
-            sf, res = 2 ** (bits - 1), op.value
+            sf, res = pow(2, bits - 1), op.value
 
             # if op.value has its sign inverted, then signify it otherwise just use it
-            return -2 ** bits + res if interface.node.alt_opinverted(ea, op.n) else res & (2 ** bits - 1)
+            return pow(-2, bits) + res if interface.node.alt_opinverted(ea, op.n) else res & (pow(2, bits) - 1)
         optype = "{:s}({:d})".format('idaapi.o_imm', idaapi.o_imm)
         raise E.InvalidTypeOrValueError(u"{:s}.immediate({:#x}, {!r}) : Expected operand type `{:s}` but operand type {:d} was received.".format('.'.join([__name__, 'operand_types']), ea, op, optype, op.type))
 
@@ -1597,9 +1597,9 @@ class operand_types:
         seg, sel = (op.specval & 0xffff0000) >> 16, (op.specval & 0x0000ffff) >> 0
 
         global architecture
-        sf, dt = 2 ** (bits - 1), dtype_by_size(database.config.bits() // 8)
+        sf, dt = pow(2, bits - 1), dtype_by_size(database.config.bits() // 8)
 
-        inverted, regular = offset & (2 ** bits - 1) if offset & sf else -2 ** bits + offset, -2 ** bits + offset if offset & sf else offset & (sf - 1)
+        inverted, regular = offset & (pow(2, bits) - 1) if offset & sf else pow(-2, bits) + offset, pow(-2, bits) + offset if offset & sf else offset & (sf - 1)
         res = inverted if interface.node.alt_opinverted(ea, op.n) else regular, None if base is None else architecture.by_indextype(base, dt), None if index is None else architecture.by_indextype(index, dt), scale
         return intelops.OffsetBaseIndexScale(*res)
 

--- a/base/segment.py
+++ b/base/segment.py
@@ -103,10 +103,12 @@ def list(**type):
 
         listable.append(seg)
 
-    # Collect the maximum sizes for everything from the first pass
-    Fdigits = lambda number, base: math.floor(1. + math.log(number or 1) / math.log(base))
-    cindex = Fdigits(maxindex, 10)
-    caddr, csize = (Fdigits(item, 16) for item in [maxaddr, maxsize])
+    # Collect the maximum sizes for everything from the first pass. We have
+    # to use different algorithms as due to Python's issues with imprecision,
+    # the resulting number of digits will vary depending on what base is
+    # actually being used when calculating the logarithm.
+    cindex = 1 + math.floor(math.log10(maxindex or 1))
+    caddr, csize = map(math.ceil, (math.log(item or 1, 16) for item in [maxaddr, maxsize]))  # ceiling only works for powers of 16
 
     # List all the fields for each segment that we've aggregated
     for seg in listable:
@@ -165,7 +167,7 @@ def by(**type):
     listable = [item for item in __iterate__(**type)]
     if len(listable) > 1:
         maxaddr = max(builtins.map(interface.range.end, listable) if listable else [1])
-        caddr = math.floor(1. + math.log(maxaddr or 1) / math.log(16))
+        caddr = math.ceil(math.log(maxaddr or 1, 16))   # only works with powers of 16
         messages = ((u"[{:d}] {:0{:d}x}:{:0{:d}x} {:s} {:+#x} sel:{:04x} flags:{:02x}".format(seg.index, interface.range.start(seg), math.trunc(caddr), interface.range.end(seg), math.trunc(caddr), utils.string.of(get_segment_name(seg)), seg.size(), seg.sel, seg.flags)) for seg in listable)
         [ logging.info(msg) for msg in messages ]
         logging.warning(u"{:s}.by({:s}) : Found {:d} matching results. Returning the first segment at index {:d} from {:0{:d}x}<>{:0{:d}x} with the name {:s} and size {:+#x}.".format(__name__, searchstring, len(listable), listable[0].index, interface.range.start(listable[0]), math.trunc(caddr), interface.range.end(listable[0]), math.trunc(caddr), utils.string.of(get_segment_name(listable[0])), listable[0].size()))

--- a/base/segment.py
+++ b/base/segment.py
@@ -108,7 +108,7 @@ def list(**type):
     # the resulting number of digits will vary depending on what base is
     # actually being used when calculating the logarithm.
     cindex = 1 + math.floor(math.log10(maxindex or 1))
-    caddr, csize = map(math.ceil, (math.log(item or 1, 16) for item in [maxaddr, maxsize]))  # ceiling only works for powers of 16
+    caddr, csize = map(math.ceil, (math.log(item or 1, 16) for item in [maxaddr, maxsize]))  # taking the ceiling only works for powers of 2
 
     # List all the fields for each segment that we've aggregated
     for seg in listable:

--- a/misc/ui.py
+++ b/misc/ui.py
@@ -446,9 +446,10 @@ class strings(appwindow):
         else:
             res = [idaapi.STRTYPE_TERMCHR, idaapi.STRTYPE_PASCAL, idaapi.STRTYPE_LEN2, idaapi.STRTYPE_C_16, idaapi.STRTYPE_LEN4, idaapi.STRTYPE_LEN2_16, idaapi.STRTYPE_LEN4_16]
 
-        config.strtypes = functools.reduce(lambda t, c: t | (2**c), res, 0)
+        config.strtypes = functools.reduce(lambda result, item: result | pow(2, item), res, 0)
         if not idaapi.set_strlist_options(config):
             raise internal.exceptions.DisassemblerError(u"{:s}.__on_openidb__({:#x}, {:b}) : Unable to set the default options for the string list.".format('.'.join([__name__, cls.__name__]), code, is_old_database))
+        return
         #assert idaapi.build_strlist(config.ea1, config.ea2), "{:#x}:{:#x}".format(config.ea1, config.ea2)
 
     @classmethod


### PR DESCRIPTION
Due to python's imprecision, certain logarithms will result in the wrong value where the value is off by around `1e-15`. Due to this, taking the floor of the logarithm's value will result in a completely wrong result. This type of calculation is used in a variety of places in order to determine the number of bits or digits for a given integer. Some examples where the logarithm result is off is when the base 10 logarithm is calculated for 1000. Logarithms for base 2 will also demonstrate an incorrect result for similar reasons.

This PR attempts to fix these calculations by ensuring that `math.log10` is used for any base 10 calculations, and when calculating base 2 calculations the ceiling is taken rather than the floor. Testing these changes against a number of boundaries for powers of 2 seems to result in the "length" of the integer being of the expected value.

We now ensure that base 10 numbers are always calculated with `f(n) = 1 + math.floor(math.log10(n))` which uses the `math.log10` function available in both Python2 and Python3 and demonstrates correctness. As the `math.log2` function is only available on Python3 (and not Python2), the function `f(n, b) = math.ceil(math.log(n, b))` is used for calculating the logarithm. WIth this, base 2 numbers use `f(n, 2) = math.ceil(math.log(n, 2))`, and base 16 numbers  use `f(n, 16) = math.ceil(math.log(n, 16))`.

This closes issue #129.