### PR TITLE
Fixed the implementation of the `instruction.op_refs` function so that it supports all of the available reference types.

### DIFF
--- a/base/instruction.py
+++ b/base/instruction.py
@@ -1664,6 +1664,10 @@ def op_refs(ea, opnum):
             res.extend(interface.opref_t(ea, int(op), interface.reftype_t.of(t)) for op in filtered)
         return res
 
+    # If our operand type is a register, then there's no structures here.
+    elif operand(inst.ea, opnum).type in {idaapi.o_reg}:
+        raise E.MissingTypeOrAttribute(u"{:s}.op_structure({:#x}, {:d}) : Operand {:d} has a type ({:d}) that cannot contain a structure.".format(__name__, inst.ea, opnum, opnum, operand(inst.ea, opnum).type))
+
     # Anything else should be just a regular global reference, and to figure this out
     # we just grab the operand's value and work it out from there. The value at the
     # supidx has some format which is documented as "complex reference information".

--- a/base/structure.py
+++ b/base/structure.py
@@ -1431,10 +1431,15 @@ class members_t(object):
         F = filter or (lambda structure, items: items)
         filtered = F(owner.ptr, members) if len(members) > 1 else members
 
-        # If we still do not have a single result after filtering, then
-        # we terminate our traversal here with the nearest member, and
-        # include the offset that's relative to it.
-        if len(filtered) != 1:
+        # If we didn't get any members, then just return the delta amd
+        # terminate our traversal.
+        if not len(filtered):
+            return (), offset
+
+        # If we didn't get a single result after filtering, then we will
+        # terminate our traversal here with the nearest member, and include
+        # the offset that's relative to our findings.
+        if len(filtered) > 1:
             nearest = self.near_realoffset(offset)
             return (nearest,), offset - nearest.realoffset
 

--- a/base/structure.py
+++ b/base/structure.py
@@ -1344,7 +1344,7 @@ class members_t(object):
                 # a legitimate candidate.
                 elif isinstance(res, structure_t):
                     mem = idaapi.get_member(res.ptr, realoffset)
-                    selected.append(mptr) if realoffset - mem.soff else selected.insert(0, mptr)
+                    selected.append(mptr) if mem and realoffset - mem.soff else selected.insert(0, mptr)
 
                 # If it's a tuple, then this only matches if we're pointing
                 # directly to the member.


### PR DESCRIPTION
When the enhancement introduced by PR #131, the `instruction.op_refs` function would not reliably return all of the references for a given operand. This included enumerations and most importantly structure paths where a member in the path is an explicit union. Structure offset operands that did not include any members (such as size, or references to the structure) would also not be included in the returned results.

This PR fixes all of those issues, and reworks the `instruction.op_structure` function so that it includes support for structure paths that do not have any members. The `instruction.op_refs` function also supports these properly, and it also includes references to both globals and stack variables that use the operand specified by the user. The delta parameter was also removed from the `instruction.op_structure` function instead opting to include it via the path. The original cases for `instruction.op_structure` rip the delta out of the keyword and push it to the end of the path in order to remain compatible with the previously existing api.

This fixes issue #133.