### PR TITLE
Added guards around all instances of the `idaapi.get_member_by_id` function to guarantee a proper `idaapi.struc_t` is returned.

### DIFF
--- a/base/structure.py
+++ b/base/structure.py
@@ -370,7 +370,10 @@ class structure_t(object):
             if mpack is None:
                 cls = self.__class__
                 raise E.MemberNotFoundError(u"{:s}({:#x}).refs() : Unable to locate the member identified by {:#x}.".format('.'.join([__name__, cls.__name__]), self.id, ref))
+
             mptr, name, sptr = mpack
+            if not interface.node.is_identifier(sptr.id):
+                sptr = idaapi.get_member_struc(idaapi.get_member_fullname(mptr.id))
 
             # Validate that the type of the mptr is what we're expecting.
             if not isinstance(mptr, idaapi.member_t):
@@ -1356,10 +1359,12 @@ class members_t(object):
             raise E.MemberNotFoundError(u"{:s}({:#x}).members.by_id({:#x}) : Unable to find member with specified identifier ({:#x}).".format('.'.join([__name__, cls.__name__]), owner.ptr.id, id, id))
 
         # unpack the member out of the result
-        mem, fn, st = res
+        mptr, fullname, sptr = res
+        if not interface.node.is_identifier(sptr.id):
+            sptr = idaapi.get_member_struc(idaapi.get_member_fullname(mptr.id))
 
         # search through our members for the specified member
-        index = self.index(mem)
+        index = self.index(mptr)
         return self[index]
     by_id = byid = byidentifier = utils.alias(by_identifier, 'members_t')
 


### PR DESCRIPTION
The `idaapi.get_member_by_id` function is supposed to return a tuple composed of the `idaapi.member_t`, its full name, and the `idaapi.struc_t` that contains it. In some cases, this IDAPython api can return a busted-up `idaapi.struc_t`. This `idaapi.struc_t` acts pretty fucked up, and doesn't let you access its id properly which we completely depend on. This api is used by the `instruction.op_structure` set of functions and the `structure` module.

To work around this issue, we first attempt the original `idaapi.get_member_by_id` call. Once we unpack the result, we immediately check the id for the `idaapi.struc_t` that is returned. If this id is undefined, then we re-fetch the `idaapi.struc_t` using a combination of `idaapi.get_member_struc` and `idaapi.get_member_fullname` using the original `idaapi.member_t` identifier.

This adds the necessary workaround for resolving issue #135.