### PR TITLE
Added a fallback implementation for instances of IDA where the _ida_netnode.netnode_exist isn't available.

### DIFF
--- a/base/_netnode.py
+++ b/base/_netnode.py
@@ -36,12 +36,16 @@ class netnode(object):
     index = _ida_netnode.netnode_index
     kill = _ida_netnode.netnode_kill
 
-    # these apis exist in 5.6 of the sdk, but there's
-    # definitely a chance that they're not in IDAPython.
-    if idaapi.__version__ > 7.1:
-        exist, exist_name = _ida_netnode.exist, _ida_netnode.netnode_exist
+    # Although the following apis exist in 5.6 of the sdk, there's a chance that
+    # they're not actually available in IDAPython. To deal with that uncertainty,
+    # we'll explicitly check for it and assign if so, otherwise we have to use
+    # the _ida_netnode.new_netnode function with its "do_create" parameter set
+    # to false.
+    exist = _ida_netnode.exist
+    if hasattr(_ida_netnode, 'netnode_exist'):
+        exist_name = _ida_netnode.netnode_exist
     else:
-        exist, exist_name = _ida_netnode.exist, internal.utils.fcompose(internal.utils.frpartial(_ida_netnode.new_netnode, False, 0), _ida_netnode.netnode_index, internal.utils.fpartial(operator.ne, idaapi.BADADDR))
+        exist_name = internal.utils.fcompose(internal.utils.frpartial(_ida_netnode.new_netnode, False, 0), _ida_netnode.netnode_index, internal.utils.fpartial(operator.ne, idaapi.BADADDR))
 
     long_value = _ida_netnode.netnode_long_value
     next = _ida_netnode.netnode_next


### PR DESCRIPTION
On earlier versions of IDA (5.6), the `netnode_exist` function is defined in the SDK, but is not actually available in IDAPython. As a result of this discovery, a fallback implementation was defined in commit ff3b1a907f4e05934cadfaece64a2c2c0ad65b70 that used the `_ida_netnode.new_netnode` function with its "do_create" parameter set to `False`. This implementation was then chosen when an earlier version of IDA was detected.

Unfortunately, as reported in issue #137, it was discovered that later versions of IDA don't always include this function in IDAPython. As a result of this, it was decided to replace the version-check that distinguishes whether to use the fallback implementation (or not) with an explicit check for the `_ida_netnode.netnode_exist` function. If this function exists within the `_ida_netnode` module, then we assign it to `netnode.exist_name`. If it doesn't, then we fallback to the `_ida_netnode.new_netnode` implementation to determine if a netnode with the given name is defined within the database.

This fixes issue #137.