### PR TITLE
Fixed the way that the multicase decorator works so that all the arguments are properly checked against their constraints when matching.

### DIFF
--- a/base/_utils.py
+++ b/base/_utils.py
@@ -545,13 +545,13 @@ class multicase(object):
             # decorated with. If our constraint is a builtins.callable, then we just need to
             # ensure that the parameter can be called. Otherwise our constraint should be an
             # iterable of types that we can simply pass long to the isinstance() function.
-            critiqueF = lambda constraint: builtins.callable if constraint == builtins.callable else finstance(*constraint)
+            critiqueF = lambda constraint: builtins.callable if constraint == builtins.callable else frpartial(builtins.isinstance, constraint)
 
             # Zip our parameter names along with our argument values so that we can extract
             # the contraint, and check the value against it. If any of these checks fail,
             # then it's not a match and we need to move on to the next iteration.
             parameter_names_and_values = zip(parameter_names[parameter_ignore_count:], argument_values)
-            if not all(critiqueF(constraints[name])(value) for name, value in parameter_names_and_values):
+            if not all(critiqueF(constraints[name])(value) for name, value in parameter_names_and_values if name in constraints):
                 continue
 
             # We should now have a match. So now that we've figured out all of our individual

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -329,7 +329,7 @@ class multicase(object):
             # also check to see if it's using the magic name "__new__" which takes
             # an implicit parameter that gets passed to it.
             args, defaults, (star, starstar) = cls.ex_args(func)
-            s_args = 1 if isinstance(wrapped, (classmethod, types.MethodType)) else 0
+            s_args = 1 if isinstance(wrapped, (classmethod, types.MethodType)) or func.__name__ in {'__new__'} else 0
 
             # If the user decorated us whilst explicitly providing the previous
             # function that this case is a part of, then make sure that we use it.

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -392,16 +392,22 @@ class multicase(object):
     @classmethod
     def document(cls, name, cache):
         '''Generate documentation for a multicased function.'''
-        res = []
-        for func, types, _ in cache:
-            doc = (func.__doc__ or '').split('\n')
+        result = []
+
+        # Iterate through every item in our cache, and generate the prototype for it.
+        for function, constraints, (ignore_count, parameter_names, _, _) in cache:
+            prototype = cls.prototype(function, constraints, parameter_names[:ignore_count])
+
+            # Now that we have the prototype, we need to figure out where we need to
+            # add the documentation for the individual case.
+            doc = (function.__doc__ or '').split('\n')
             if len(doc) > 1:
-                res.append("{:s} ->".format(cls.prototype(func, types)))
-                res.extend("{: >{padding:d}s}".format(item, padding=1 + len(name) + len(item)) for item in map(operator.methodcaller('strip'), doc))
+                result.append("{:s} ->".format(prototype))
+                result.extend("{: >{padding:d}s}".format(item, padding=1 + len(name) + len(item)) for item in map(operator.methodcaller('strip'), doc))
             elif len(doc) == 1:
-                res.append(cls.prototype(func, types) + (" -> {:s}".format(doc[0]) if len(doc[0]) else ''))
+                result.append("{:s} -> {:s}".format(prototype, doc[0]) if len(doc[0]) else '')
             continue
-        return '\n'.join(res)
+        return '\n'.join(result)
 
     @classmethod
     def prototype(cls, function, constraints={}, ignored={item for item in []}):

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -465,7 +465,7 @@ class multicase(object):
             # build the argument tuple using the generator, kwds, or our defaults.
             a = []
             try:
-                for n in af[sa:]:
+                for n in af:
                     try: a.append(next(ac))
                     except StopIteration: a.append(kc.pop(n) if n in kc else defaults.pop(n))
             except KeyError: pass
@@ -477,14 +477,14 @@ class multicase(object):
                 continue
 
             # if our perceived argument length doesn't match, then this iteration doesn't match either
-            if len(a) != len(af[sa:]):
+            if sa + len(a) != len(af):
                 continue
 
             # figure out how to match the types by checking if it's a regular type or it's a callable
             predicateF = lambda t: callable if t == callable else (lambda v: isinstance(v, t))
 
             # now we can finally start checking that the types match
-            if any(not predicateF(ts[t])(v) for t, v in zip(af[sa:], a) if t in ts):
+            if not all(predicateF(ts[t])(v) for t, v in zip(af[sa:], a) if t in ts):
                 continue
 
             # we should have a match
@@ -501,7 +501,8 @@ class multicase(object):
         def F(*arguments, **keywords):
             heap = [res for _, res in heapq.nsmallest(len(cache), cache, key=operator.attrgetter('priority'))]
             f, (a, w, k) = cls.match((arguments[:], keywords), heap)
-            return f(*arguments, **keywords)
+            return f(*itertools.chain(a, w), **k)
+            #return f(*arguments, **keywords)
             #return f(*(arguments + tuple(w)), **keywords)
 
         # swap out the original code object with our wrapper's

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -411,7 +411,7 @@ class multicase(object):
         def flatten(iterable):
             '''This closure takes the provided `iterable` (or tree), and flattens it into a list.'''
             for item in iterable:
-                if isinstance(item, (builtins.list, builtins.tuple)):
+                if isinstance(item, (builtins.list, builtins.tuple, builtins.set)):
                     for item in flatten(item):
                         yield item
                     continue
@@ -546,7 +546,8 @@ class multicase(object):
         # If we iterated through everything in our heap, then we couldn't find a match for the
         # types the user gave us. So we need to raise an exception to inform the user that the
         # types we were given did not match any of the constraints that we know about.
-        error_arguments = [item.__class__.__name__ for item in args]
+        ignored = min(ignore_count for _, _, (ignore_count, _, _, _) in heap) if heap else 0
+        error_arguments = [item.__class__.__name__ for item in args[ignored:]]
         error_keywords = ["{:s}={!s}".format(name, kwds[name].__class__.__name__) for name in kwds]
         error_prototypes = [cls.prototype(F, constraints) for F, constraints, _ in heap]
         raise internal.exceptions.UnknownPrototypeError(u"@multicase.call({:s}{:s}): The requested argument types do not match any of the available prototypes. The prototypes that are available are: {:s}.".format(', '.join(error_arguments) if args else '*()', ", {:s}".format(', '.join(error_keywords)) if error_keywords else '', ', '.join(error_prototypes)))

--- a/base/_utils.py
+++ b/base/_utils.py
@@ -424,10 +424,11 @@ class multicase(object):
             # add the documentation for the individual case.
             doc = (function.__doc__ or '').split('\n')
             if len(doc) > 1:
-                result.append("{:s} ->".format(prototype))
-                result.extend("{: >{padding:d}s}".format(item, padding=1 + len(name) + len(item)) for item in map(operator.methodcaller('strip'), doc))
+                item, lines = "{:s} -> ".format(prototype), (item for item in doc)
+                result.append("{:s}{:s}".format(item, next(lines)))
+                result.extend("{: >{padding:d}s}".format(line, padding=len(item) + len(line)) for line in map(operator.methodcaller('strip'), lines))
             elif len(doc) == 1:
-                result.append("{:s} -> {:s}".format(prototype, doc[0]) if len(doc[0]) else '')
+                result.append("{:s}{:s}".format(prototype, " -> {:s}".format(doc[0]) if len(doc[0]) else ''))
             continue
         return '\n'.join(result)
 


### PR DESCRIPTION
While working on some of the navigators inside the `database.address` namespace, it was discovered that some of the arguments types were being checked more than once. More importantly, however, the arguments types were being collected prior to returning them to the caller.. yet, in all actuality, they were not being used when dispatching to the matched function. Instead what was happening, was that the original arguments were then being passed to the matched function using python's internal function argument dispatcher and the original parameters the user gave us. Although this still worked properly, it was not actually how I originally intended the decorator to be used.

Due to the way a particular condtional was being used in `utils.multicase.match`, any functions that were matched with duplicate parameter names would not have their first parameter (the class or instance) checked. This was due to the function being incorrectly decorated. Again though, this didn't affect anything because the first parameter was being discarded and ignored if the function was decorated as an instancemethod or a classmethod. Nonetheless, this was fixed so that if the user wants they can also specify a type constraint for the class or instance that's being passed as the first parameter instead of us just ignoring it like we were doing previously.

The decorated documentation that is generated was also fixed to remove the first parameter that's implicitly included. As this parameter is generally irrelevant, the displaying of it along with its type takes up extra unnecessary space which would be better if it was occupied by actual relevant information.

This fixes issue #146.