### PR TITLE
Fixed the `meta_path` used for the darwin platform to add the 64-bit variation of the shared object filename

### DIFF
--- a/idapythonrc.py
+++ b/idapythonrc.py
@@ -230,7 +230,7 @@ if sys.platform in {'darwin'}:
     sys.meta_path.append( internal_object('ida', library(idaapi.idadir("libida{:s}.dylib".format('' if idaapi.BADADDR < 0x100000000 else '64')))) )
 
 elif sys.platform in {'linux', 'linux2'}:
-    sys.meta_path.append( internal_object('ida', library("libida{:s}.so".format('' if idaapi.BADADDR < 0x100000000 else '64'))) )
+    sys.meta_path.append( internal_object('ida', library(idaapi.idadir("libida{:s}.so".format('' if idaapi.BADADDR < 0x100000000 else '64')))) )
 
 elif sys.platform in {'win32'}:
     if __import__('os').path.exists(idaapi.idadir('ida.wll')):
@@ -239,7 +239,7 @@ elif sys.platform in {'win32'}:
         sys.meta_path.append( internal_object('ida', library(idaapi.idadir("ida{:s}.dll".format('' if idaapi.BADADDR < 0x100000000 else '64')))) )
 
 else:
-    __import__('logging').warning("{:s} : Unable to successfully load IDA's native api with ctypes.".format(__name__))
+    __import__('logging').warning("{:s} : Unable to successfully load IDA's native api via ctypes. Ignoring...".format(__name__))
 
 ## private (internal) api
 sys.meta_path.append( internal_submodule('internal', os.path.join(root, 'base'), include='_*.py') )

--- a/idapythonrc.py
+++ b/idapythonrc.py
@@ -227,7 +227,7 @@ class plugin_module(object):
 
 ## IDA's native lower-level api
 if sys.platform in {'darwin'}:
-    sys.meta_path.append( internal_object('ida', library(idaapi.idadir('libida.dylib'))) )
+    sys.meta_path.append( internal_object('ida', library(idaapi.idadir("libida{:s}.dylib".format('' if idaapi.BADADDR < 0x100000000 else '64')))) )
 
 elif sys.platform in {'linux', 'linux2'}:
     sys.meta_path.append( internal_object('ida', library("libida{:s}.so".format('' if idaapi.BADADDR < 0x100000000 else '64'))) )


### PR DESCRIPTION
When the plugin initializes its base namespace, it uses Python's `meta_path` to add a finder that allows the user to interact with the native IDA shared object using the `ctypes` library. This allows one to interact with the exports that IDA's API exposes to a user in the situation that the desired functionality is not exposed by the IDAPython SWIG interface.

It was identified that the library on the "darwin" platfrom was incomplete and only included the path for the 32-bit version of IDA. This was due to an oversight by the author and was fixed by testing whether the 32-bit or 64-bit version of IDA is running and choosing the correct filename based on the detected version.

On the "darwin" platform, the 32-bit version of the library is "libida.dylib" and the 64-bit version of the library is "libida64.dylib". Similar to the way the internal is determined for the other platforms, the value for `idaapi.BADADDR` is checked and used to determine whether to add the "64" suffix or not. The "linux" platform was also updated to use `idaapi.idadir` to determine the installation directory and locate the correct native library.

This fixes issue #149.