### PR TITLE
Modified all instances where the "referers" of a function tail is checked to verify the quantity in "refqty" before accessing the property.

### DIFF
--- a/base/_comment.py
+++ b/base/_comment.py
@@ -831,15 +831,15 @@ class contents(tagging):
                 logging.critical(u"{:s}._key({:#x}) : Unable to read more than one referrer ({:d}) for the function tail at {!s}. The \"{:s}\" attribute is {!s}.".format('.'.join([__name__, cls.__name__]), ea, count, bounds, 'referers', ch.referers))
                 return internal.interface.range.start(res)
 
-            # Otherwise we can just use idaapi.get_func() to get the owner.
-            elif ch.referers is None:
+            # If there's no referrers or the number of them is one, then
+            # we'll just rely on idaapi.get_func() to get the owner.
+            elif ch.referers is None or count == 1:
                 return internal.interface.range.start(res)
 
             # If we didn't get an array with a count, then we're using
             # an older version of IDA where we need to construct it.
             referers = ch.referers if hasattr(ch.referers, 'count') else tids.frompointer(ch.referers)
-            owners = [referers[index] for index in range(count)]
-            return owners if len(owners) > 1 else owners[0]
+            return [referers[index] for index in range(count)]
         return internal.interface.range.start(res)
 
     @classmethod

--- a/base/function.py
+++ b/base/function.py
@@ -573,9 +573,9 @@ class chunk(object):
             if ch.referers is None and count > 1:
                 raise internal.exceptions.DisassemblerError(u"{:s}.owners({:#x}) : Unable to read more than one referrer ({:d}) for the function tail at {!s}. The \"{:s}\" attribute is {!s}.".format('.'.join([__name__, cls.__name__]), ea, count, bounds, 'referers', ch.referers))
 
-            # Otherwise, we can handle this by using the function that
-            # we snagged in order to determine the owner of the address.
-            elif ch.referers is None:
+            # If it's still None or there's only one referrer, then we
+            # use the func_t we snagged in order to determine the owner.
+            elif ch.referers is None or count == 1:
                 referers = [ internal.interface.range.start(fn) ]
 
             # Our referers are normal, so we can simply convert them


### PR DESCRIPTION
It seems that the `func_t.referers` attribute is super unstable and almost racy when it is fetched by `idaapi.get_fchunk`. What you're supposed to do is use `idaapi.get_fchunk` to get a `func_t`, then check the `func_t.flags` for the `FUNC_TAIL` flag. If this is set, then the `func_t.referers` attribute contains a list of the referrers (or owners) for that particular function chunk. This attribute has a "count" attribute which you can use to check how many elements are in the array. There are instances where the "count" attribute is set to 1, but as soon as you access the first element of the array it dereferences a null-pointer. Historically, this attribute has been super-unstable but you could work around it in most cases. It seems that now with 7.7 it is as unreliable as all hell.

This PR works around this issue by checking the `func_t.refqty` attribute before accessing the `func_t.referers` attribute. If the `func_t.refqty` attribute is 1, then it completely avoids accessing the referers instead and falling back to `idaapi.get_func` to get the owner. This will work for most situations, but anytime the number of referers is greater than 1, this risks the null pointer dereference. I'm reporting the issue to support@hex-rays.com, but instead of waiting will probably push this fix as I still need to do my regular job...

This fixes issue #154.