### PR TITLE
Fixed the mapping of `type` to the pointer type which is used for describing structure fields.

### DIFF
--- a/base/_interface.py
+++ b/base/_interface.py
@@ -106,7 +106,7 @@ class typemap(object):
         if hasattr(builtins, 'unicode'):
             stringmap.setdefault(builtins.unicode, (idaapi.asciflag(), idaapi.ASCSTR_UNICODE))
 
-        ptrmap = { sz : (idaapi.offflag() | flg, tid) for sz, (flg, tid) in integermap.items() }
+        ptrmap = { sz : (idaapi.offflag() | flg, 0) for sz, (flg, _) in integermap.items() }
         nonemap = { None :(idaapi.alignflag(), -1) }
 
     ## IDA 7.0 types
@@ -133,7 +133,7 @@ class typemap(object):
         if hasattr(builtins, 'unicode'):
             stringmap.setdefault(builtins.unicode, (idaapi.strlit_flag(), idaapi.STRTYPE_C_16))
 
-        ptrmap = { sz : (idaapi.off_flag() | flg, tid) for sz, (flg, tid) in integermap.items() }
+        ptrmap = { sz : (idaapi.off_flag() | flg, 0) for sz, (flg, _) in integermap.items() }
         nonemap = { None :(idaapi.align_flag(), -1) }
 
     # Generate the lookup table for looking up the correct tables for a given type.

--- a/base/_interface.py
+++ b/base/_interface.py
@@ -155,6 +155,8 @@ class typemap(object):
         inverted[f & FF_MASKSIZE] = (float, s)
     for s, (f, _) in stringmap.items():
         inverted[f & FF_MASKSIZE] = (str, s)
+    for s, (f, _) in nonemap.items():
+        inverted[f & FF_MASKSIZE] = (None, s)
 
     # Add all the available flag types to support all available pointer types.
     for s, (f, _) in ptrmap.items():

--- a/base/database.py
+++ b/base/database.py
@@ -6220,11 +6220,14 @@ class set(object):
         else:
             realtype, reallength = [type, length], length
 
-        # now we can figure out its IDA type
+        # now we can figure out its IDA type and create the data. after
+        # that, though, we need to update its refinfo before we leave.
         flags, typeid, nbytes = interface.typemap.resolve(realtype)
-        ok = idaapi.create_data(ea, flags, nbytes, typeid)
-        if not ok:
+        if not idaapi.create_data(ea, flags, nbytes, typeid):
             raise E.DisassemblerError(u"{:s}.array({:#x}, {!r}, {:d}) : Unable to define the specified address as an array.".format('.'.join([__name__, cls.__name__]), ea, type, length))
+        interface.typemap.update_refinfo(ea, flags)
+
+        # return the array that we just created.
         return get.array(ea, length=reallength)
 
 class get(object):

--- a/base/structure.py
+++ b/base/structure.py
@@ -1504,17 +1504,10 @@ class members_t(object):
         # parameters that we were given and/or figured out.
         res = idaapi.add_struc_member(owner.ptr, utils.string.to(name), realoffset, flag, opinfo, nbytes)
 
-        # Now we can check whether the addition was succesful or not. If the
-        # addition didn't return an error code, then log the success in order
-        # to assist with debugging.
-        if res == idaapi.STRUC_ERROR_MEMBER_OK:
-            cls = self.__class__
-            logging.debug(u"{:s}({:#x}).members.add({!r}, {!s}, {:+#x}) : The api call to `idaapi.add_struc_member(sptr=\"{:s}\", fieldname=\"{:s}\", offset={:+#x}, flag={:#x}, mt={:#x}, nbytes={:#x})` returned success.".format('.'.join([__name__, cls.__name__]), owner.ptr.id, name, type, offset, utils.string.escape(owner.name, '"'), utils.string.escape(name, '"'), realoffset, flag, typeid, nbytes))
-
         # If we received a failure error code, then we convert the error code to
         # an error message so that we can raise an exception that actually means
         # something and enables the user to correct it.
-        else:
+        if res != idaapi.STRUC_ERROR_MEMBER_OK:
             error = {
                 idaapi.STRUC_ERROR_MEMBER_NAME : 'Duplicate field name',
                 idaapi.STRUC_ERROR_MEMBER_OFFSET : 'Invalid offset',
@@ -1525,13 +1518,18 @@ class members_t(object):
             cls = self.__class__
             raise e(u"{:s}({:#x}).members.add({!r}, {!s}, {:+#x}) : The api call to `{:s}` returned {:s}".format('.'.join([__name__, cls.__name__]), owner.ptr.id, name, type, offset, callee, error.get(res, u"Error code {:#x}".format(res))))
 
-        # We added the member, but now we need to return it to the caller. Since
+        # Now we need to return the newly created member to the caller. Since
         # all we get is an error code from IDAPython's api, we try and fetch the
         # member that was just added by the offset it's supposed to be at.
         mptr = idaapi.get_member(owner.ptr, realoffset)
         if mptr is None:
             cls = self.__class__
             raise E.MemberNotFoundError(u"{:s}({:#x}).members.add({!r}, {!s}, {:+#x}) : Unable to locate recently created member \"{:s}\" at offset {:s}{:+#x}.".format('.'.join([__name__, cls.__name__]), owner.ptr.id, name, type, offset, utils.string.escape(name, '"'), realoffset, nbytes))
+
+        # We can now log our small success and update the member's refinfo if it
+        # was actually necessary.
+        cls, refcount = self.__class__, interface.typemap.update_refinfo(mptr.id, flag)
+        logging.debug(u"{:s}({:#x}).members.add({!r}, {!s}, {:+#x}) : The api call to `idaapi.add_struc_member(sptr=\"{:s}\", fieldname=\"{:s}\", offset={:+#x}, flag={:#x}, mt={:#x}, nbytes={:#x})` returned success{:s}.".format('.'.join([__name__, cls.__name__]), owner.ptr.id, name, type, offset, utils.string.escape(owner.name, '"'), utils.string.escape(name, '"'), realoffset, flag, typeid, nbytes, " ({:d} references)".format(refcount) if refcount > 0 else ''))
 
         # If we successfully grabbed the member, then we need to figure out its
         # actual index in our structure. Then we can use the index to instantiate
@@ -2487,21 +2485,29 @@ class member_t(object):
             cls = self.__class__
             raise E.DisassemblerError(u"{:s}({:#x}).type({!s}) : Unable to assign the provided type ({!s}) to the structure member {:s}.".format('.'.join([__name__, cls.__name__]), self.id, type, type, utils.string.repr(self.name)))
 
-        items = flag, typeid, nbytes
-        newflag, newtypeid, newsize = self.flag, self.typeid or idaapi.BADADDR, self.size
-        if newflag != flag:
-            cls = self.__class__
-            logging.info(u"{:s}({:#x}).type({!s}) : The provided flags ({:#x}) were incorrectly assigned as {:#x}.".format('.'.join([__name__, cls.__name__]), self.id, items, flags, newflags))
+        # verify that our type has been applied before we update its refinfo,
+        # because if it hasn't then we need to warn the user about it so that
+        # they know what's up and why didn't do what we were asked.
+        expected, expected_tid = (flag, nbytes), typeid
+        resulting, resulting_tid = (self.flag, self.size), self.typeid
 
-        if newtypeid != typeid:
+        if expected == resulting:
+            interface.typemap.update_refinfo(self.id, flag)
+        else:
             cls = self.__class__
-            logging.info(u"{:s}({:#x}).type({!s}) : The provided typeid ({:#x}) was incorrectly assigned as {:#x}.".format('.'.join([__name__, cls.__name__]), self.id, items, typeid, newtypeid))
+            logging.warning(u"{:s}({:#x}).type({!s}) : Applying the given flags and size ({:#x}, {:d}) resulted in different flags and size being assigned ({:#x}, {:d}).".format('.'.join([__name__, cls.__name__]), self.id, type, *itertools.chain(expected, resulting)))
 
-        if newsize != nbytes:
+        # smoke-test that we actually updated the type identifier and log it if it
+        # didn't actually work. this is based on my ancient logic which assumed
+        # that opinfo.tid should be BADADDR which isn't actually the truth when
+        # you're working with a refinfo. hence we try to be quiet about it.
+        if expected_tid != (resulting_tid or idaapi.BADADDR):
             cls = self.__class__
-            logging.info(u"{:s}({:#x}).type({!s}) : The provided size ({:+#x}) was incorrectly assigned as {:+#x}.".format('.'.join([__name__, cls.__name__]), self.id, items, nbytes, newsize))
+            logging.info(u"{:s}({:#x}).type({!s}) : The provided typeid ({:#x}) was incorrectly assigned as {:#x}.".format('.'.join([__name__, cls.__name__]), self.id, type, expected_tid, resulting_tid))
 
-        return newflag, newtypeid, newsize
+        # return the stuff that actually applied.
+        flag, size = resulting
+        return flag, resulting_tid, size
 
     @property
     def typeinfo(self):


### PR DESCRIPTION
The mapping of the `type` field used by both the `structure` module and some of the functions within the `database` module was not correctly being mapped to the flags that are applied to a field. This seems to manifest itself in two ways. One of which is that the size calculation for the boundaries of a type is not correct. The other way is that once the type for a field has been changed, the refinfo for the field needs to be updated.

The size calculation issue was resolved by fixing the `typemap.dissolve` implementation in the `internal.interface` module and its tables. As the offset type is not actually a size (`DT_TYPE`) and it includes operand information, the implementation needed to also include `MS_0TYPE` and `MS_1TYPE` in its checks. This was done by adding two variables, `dsize` (which contained the original value from `DT_TYPE`), and `dtype` which includes the operand information from the flags. As a result, the `inverted` table were also updated to add all 3 operand variations of the flags for each of the sizes so that they can be looked up to determine the type. Another issue that was resolved was that apparently IDA does not use `BADADDR` inside the `opinfo_t` when pointers are being used which was resolved by setting `opinfo_t.tid` to 0 when a pointer type gets created.

The reference information was resolved by the introduction of the `typemap.update_refinfo` function which calculates which operands for a given address are set, and then updates the address' reference information using the correct size as determined from the flags (`DT_TYPE`).

After these additions, the `database.set.array`function , the `structure.members_t.add` method, and the `structure.member_t.type` property all needed to be updated so that the reference gets added. Unfortunately, the view of the database is not being updated which makes it appear as if the type wasn't applied despite it being correct in the database. This addition also results in any array within the database being treated as an offset by default. This is because IDA sets the reftype for all arrays anyways if the integer actually references something in the database. For the record, there's no explicit support for user-defined reference types without using the `refinfo_desc_t` as a map, so using the size to figure this out is literally the only viable option.

Fixes issue #156.