### PR TITLE
Added another alias to the `config.is_sharedobject` function as `config.is_dll` for the people whom are windows-centric.

### DIFF
--- a/base/database.py
+++ b/base/database.py
@@ -184,7 +184,7 @@ class config(object):
         if idaapi.__version__ < 7.0:
             raise E.UnsupportedVersion(u"{:s}.is_sharedobject() : This function is only supported on versions of IDA 7.0 and newer.".format('.'.join([__name__, cls.__name__])))
         return True if cls.lflags(idaapi.LFLG_IS_DLL) else False
-    sharedobject = is_shared = sharedQ = utils.alias(is_sharedobject, 'config')
+    sharedobject = is_shared = is_dll = sharedQ = utils.alias(is_sharedobject, 'config')
 
     @classmethod
     def is_kernelspace(cls):


### PR DESCRIPTION
As requested in issue #167, the `config.is_sharedobject` naming might be unfamiliar for users that may have originated exclusively from the windows platform. This PR simply adds an alias for it as `config.is_dll`. Generally the contents of the namespace that this function resides within is unused, but the disassembler uses the naming scheme that is being discussed. Hence, it makes sense to add this alias as a just-in-case mechanism.

This fixes issue #167.
