### PR TITLE
Added some minor fixes to the README.md file for users on the windows platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ to augment their reversing endeavors without distraction.
 
 Installation should be pretty simple and requires simply cloning the repository
 directly into the user's IDA user directory. On the Windows platform, this is
-typically located at `$APPDATA/Roaming/Hex-Rays/IDA Pro`. Whereas on the Linux
+typically located at `%APPDATA%/Hex-Rays/IDA Pro`. Whereas on the Linux
 platform this can be found at `$HOME/.idapro`. This contents of this repository
 should actually replace that directory. If you have any files that presently
 reside there, simply move them into the repository's directory. After

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ is in the root of the repository as `requirements.txt`.
 
 To install the required Python dependencies, one can run `pip` as so:
 
-    $ pip install -r 'requirements.txt'
+    $ pip install -r "requirements.txt"
 
 At this point when the user starts IDA Pro, IDA-minsc will replace IDAPython's
 namespace with its own at which point can be used immediately. To verify that


### PR DESCRIPTION
As suggested in issues #172 and #173, some of the documentation that is suggested in the `README.md` file may not be clear for users on the Windows platform. This includes the command for using `pip` to install the requirements, which was using single-quotes instead of double-quotes, and an environment variable that was using a `$`-prefixed name instead of the `%`-cuddled one that is associated with the windows command prompt. If we wanted to use Powershell's syntax, we could use `$Env:APPDATA`, but since this is so minor that it should be implied...I really don't even think it's worth the effort. Nonetheless, this PR corrects both instances using the exact suggestions as requested by the user in their issue reports.

This fixes issue #172 and #173.