### PR TITLE
Added some aliases for the `database.go` function as requested by a user.

### DIFF
--- a/base/database.py
+++ b/base/database.py
@@ -1449,6 +1449,7 @@ def go(ea):
         ea = search.by_name(None, ea)
     idaapi.jumpto(interface.address.inside(ea))
     return ea
+jump = jump_to = jumpto = utils.alias(go)
 
 def go_offset(offset):
     '''Jump to the specified `offset` within the database.'''


### PR DESCRIPTION
As requested by a user in issue #178, the `database.go` function could use some aliases related to the verb, "jump", since apparently "go" is more commonly associated with debugging commands. Thus, this PR adds aliases for it as `database.jump`, `database.jumpto`, and `database.jump_to`.

This closes issue #178.